### PR TITLE
Add IMEX sweeper, clean up existing programs

### DIFF
--- a/src/programs/libpfasst_swe_sphere_expl_sdc/ceval.cpp
+++ b/src/programs/libpfasst_swe_sphere_expl_sdc/ceval.cpp
@@ -261,31 +261,4 @@ void ceval(SphereDataVars *i_Y,
 }
 
 
-// applies artificial diffusion to the system
-void cfinalize(
-		SphereDataVars *io_Y,
-		double i_t,
-		double i_dt,
-		SphereDataCtxSDC *i_ctx
-)
-{
-	// get the simulation variables
-	SimulationVariables* simVars = i_ctx->get_simulation_variables();
-
-	if (simVars->sim.viscosity == 0)
-		return;
-
-	SphereData_Spectral& phi_pert_Y  = io_Y->get_phi_pert();
-	SphereData_Spectral& vrt_Y = io_Y->get_vrt();
-	SphereData_Spectral& div_Y  = io_Y->get_div();
-
-	const double scalar = simVars->sim.viscosity*i_dt;
-	const double r      = simVars->sim.sphere_radius;
-
-	phi_pert_Y  = phi_pert_Y.spectral_solve_helmholtz(1.0,  -scalar, r);
-	vrt_Y = vrt_Y.spectral_solve_helmholtz(1.0, -scalar, r);
-	div_Y  = div_Y.spectral_solve_helmholtz(1.0,  -scalar, r);
-}
-
-
 }

--- a/src/programs/libpfasst_swe_sphere_expl_sdc/ceval.hpp
+++ b/src/programs/libpfasst_swe_sphere_expl_sdc/ceval.hpp
@@ -43,12 +43,6 @@ extern "C"
 		SphereDataCtxSDC *i_ctx,
 		SphereDataVars *o_F1
 		);
-
-  // applies artificial diffusion
-  void cfinalize (SphereDataVars *io_Y,
-		  double i_t,
-		  double i_dt,
-		  SphereDataCtxSDC *i_ctx);
   
 }
 

--- a/src/programs/libpfasst_swe_sphere_expl_sdc/feval.f90
+++ b/src/programs/libpfasst_swe_sphere_expl_sdc/feval.f90
@@ -20,7 +20,6 @@ module feval_module
         procedure :: f_comp                => sweet_f_comp
         procedure :: initialize            => sweet_sweeper_initialize
         procedure :: destroy               => sweet_sweeper_destroy
-        procedure :: compute_dt            => sweet_sweeper_compute_dt
     end type sweet_sweeper_t
   
     ! prototypes of the C functions
@@ -44,12 +43,6 @@ module feval_module
             type(c_ptr),    value :: i_Y, i_ctx, o_F
             real(c_double), value :: i_t
         end subroutine ceval
-
-        subroutine cfinalize(i_Y, i_t, i_dt, i_ctx) bind(c, name="cfinalize")
-            use iso_c_binding
-            type(c_ptr),    value :: i_Y, i_ctx
-            real(c_double), value :: i_t, i_dt
-        end subroutine cfinalize
 
     end interface
   
@@ -155,15 +148,7 @@ contains
         integer,                  intent(in)    :: level_index
         integer,                  intent(in)    :: piece
 
-        class(sweet_data_encap_t), pointer      :: y_sd_ptr
-        class(sweet_data_encap_t), pointer      :: f_sd_ptr
-        class(sweet_data_encap_t), pointer      :: rhs_sd_ptr
-
-        y_sd_ptr   => as_sweet_data_encap(y)
-        f_sd_ptr   => as_sweet_data_encap(f)    
-        rhs_sd_ptr => as_sweet_data_encap(rhs) 
-
-        stop 'sweet_f_comp must not be called (pure explicit SDC)'
+        stop 'sweet_f_comp must not be called (pure explicit SDC)'        
             
     end subroutine sweet_f_comp
 
@@ -194,20 +179,6 @@ contains
         ! it forces Fortran to destroy the parent class data structures
         call this%imex_destroy(pf, level_index)
     end subroutine sweet_sweeper_destroy
-
-    subroutine sweet_sweeper_compute_dt(this, pf, level_index, t0, dt, flags)
-        class(sweet_sweeper_t),         intent(inout) :: this
-        type(pf_pfasst_t), target,      intent(inout) :: pf
-        integer,                        intent(in   ) :: level_index
-        real(pfdp),                     intent(in   ) :: t0
-        real(pfdp),                     intent(inout) :: dt
-        integer, optional,              intent(in   ) :: flags
-
-        type(pf_level_t),    pointer :: lev
-        lev => pf%levels(level_index)   !!  Assign level pointer
-        !  Do nothing now (copy-pasted from pf_imex_sweeper)
-        return
-    end subroutine sweet_sweeper_compute_dt
 
 end module feval_module
 

--- a/src/programs/libpfasst_swe_sphere_imex_sdc.cpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc.cpp
@@ -1,0 +1,165 @@
+/*
+ * Author: Valentina Schüller & Francois Hamon & Martin Schreiber <SchreiberX@gmail.com>
+ * MULE_COMPILE_FILES_AND_DIRS: src/programs/libpfasst_swe_sphere_imex_sdc
+ * MULE_COMPILE_FILES_AND_DIRS: src/programs/swe_sphere_benchmarks/
+ * MULE_COMPILE_FILES_AND_DIRS: src/programs/swe_sphere_timeintegrators/
+ * MULE_SCONS_OPTIONS: --sphere-spectral-space=enable
+ */
+
+
+#include <mpi.h>
+#include <sweet/sphere/SphereData_Spectral.hpp>
+#include <sweet/sphere/SphereHelpers_Diagnostics.hpp>
+#include <sweet/sphere/SphereOperators_SphereData.hpp>
+#include <sweet/SimulationVariables.hpp>
+#include "libpfasst_interface/LevelSingleton.hpp"
+#include "libpfasst_swe_sphere_imex_sdc/SphereDataCtxSDC.hpp"
+#include "swe_sphere_benchmarks/BenchmarksSphereSWE.hpp"
+#include <sweet/SWEETError.hpp>
+
+#define WITH_MPI
+
+extern "C"
+{
+/* Driver function for pfasst control */
+void fmain (SphereDataCtxSDC* pd_ctx,
+		const int*     nlevels,
+		const int*     niters,
+		const int*     nsweeps_coarse,
+		const int      nnodes[],
+		const char*    qtype_name,
+		const int*     qtype_name_len,
+		const int*     use_rk_stepper, // 1 means true, 0 means false
+		const int*     nfields,
+		const int      nvars_per_field[],
+		double*        t_max,
+		double*        dt);
+}
+
+/**
+ * Main function launching LibPFASST
+ */
+
+int main(int i_argc, char *i_argv[])
+{
+	MPI_Init(&i_argc, &i_argv);
+
+	SimulationVariables simVars;
+	LevelSingleton levelSingleton;
+
+	// input parameter names (specific ones for this program)
+	const char *bogus_var_names[] = {
+			"compute-error",
+			nullptr
+	};
+
+	// set output time scale to hours
+	simVars.iodata.output_time_scale = 1.0/(60.0*60.0);
+
+	// default values for specific input (for general input see SimulationVariables.hpp)
+	simVars.bogus.var[0] = 1;
+
+	// Help menu
+	if (!simVars.setupFromMainParameters(i_argc, i_argv, bogus_var_names))
+	{
+		std::cout << "--compute-error [0/1]Output errors (if available, default: 1)" << std::endl;
+		return -1;
+	}
+
+	// define the number of levels and SDC nodes for each level
+	// note: level #nlevels-1 is the finest, level #0 is the coarsest
+
+	int nnodes[simVars.libpfasst.nlevels];
+	nnodes[simVars.libpfasst.nlevels-1] = simVars.libpfasst.nnodes; // finest level
+
+	if (simVars.libpfasst.nlevels != 1)
+	{
+		SWEETError("For SDC, nlevels has to be equal to 1");
+	}
+
+	// set up level of levelSingleton
+	levelSingleton.level = 0;
+
+	// setup data configuration in fine level
+
+	levelSingleton.dataConfig.setupAuto(
+			simVars.disc.space_res_physical,
+			simVars.disc.space_res_spectral,
+			simVars.misc.reuse_spectral_transformation_plans,
+			simVars.misc.verbosity
+	);
+	std::cout << "SPH config string: " << levelSingleton.dataConfig.getConfigInformationString() << std::endl;
+
+	int res_physical_nodealiasing[2] = {
+			2*(simVars.disc.space_res_spectral[0]+1),
+			simVars.disc.space_res_spectral[1]+2
+	};
+
+	levelSingleton.dataConfigNoDealiasing.setupAuto(
+			res_physical_nodealiasing,
+			simVars.disc.space_res_spectral,
+			simVars.misc.reuse_spectral_transformation_plans
+	);
+
+	// setup data operators
+	levelSingleton.op.setup(
+			&(levelSingleton.dataConfig),
+			&(simVars.sim)
+	);
+	levelSingleton.opNoDealiasing.setup(
+			&(levelSingleton.dataConfigNoDealiasing),
+			&(simVars.sim)
+	);
+
+
+	// define the SWEET parameters
+
+	const int nfields = 3;  // number of vector fields (here, height and two horizontal velocities)
+	int nvars_per_field[1];
+	nvars_per_field[0] = 2 * levelSingleton.dataConfig.spectral_array_data_number_of_elements;  // number of degrees of freedom per vector field
+
+	// initialize the topography before instantiating the SphereDataCtxSDC object
+	if (simVars.benchmark.benchmark_name == "flow_over_mountain")
+	{
+		// create h_topo with the configuration at the finest level
+		simVars.benchmark.h_topo = SphereData_Physical(&(levelSingleton.dataConfig));
+
+		// initialize the topography
+		levelSingleton.benchmarks.master->setup_topography();
+	}
+
+	// instantiate the SphereDataCtxSDC object
+	SphereDataCtxSDC* pd_ctx = new SphereDataCtxSDC(
+			&simVars,
+			&levelSingleton,
+			nnodes
+	);
+
+	// get the C string length (needed by Fortran...)
+	int string_length = simVars.libpfasst.nodes_type.size();
+
+	// flag for the RK stepper
+	const int rk_stepper_flag = (simVars.libpfasst.use_rk_stepper) ? 1 : 0;
+
+	// call LibPFASST to advance in time
+	fmain(
+			pd_ctx,                                       // user defined context
+			&simVars.libpfasst.nlevels,                   // number of SDC levels
+			&simVars.libpfasst.niters,                    // number of SDC iterations
+			&simVars.libpfasst.nsweeps_coarse,            // number of SDC sweeps on coarse level
+			nnodes,                                       // number of SDC nodes
+			(simVars.libpfasst.nodes_type).c_str(),       // type of nodes
+			&string_length,                               // length of (simVars.libpfasst.nodes_type).c_str()
+			&rk_stepper_flag,                             // flag for the RK stepper => 1 means true, 0 means false
+			&nfields,                                     // number of vector fields
+			nvars_per_field,                              // number of dofs per vector field
+			&(simVars.timecontrol.max_simulation_time),   // simulation time
+			&(simVars.timecontrol.current_timestep_size)  // time step size
+	);
+
+	// release the memory
+	delete pd_ctx;
+
+	MPI_Finalize();
+}
+

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/SphereDataCtxSDC.hpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/SphereDataCtxSDC.hpp
@@ -1,0 +1,173 @@
+#ifndef _SPHERE_DATA_CTX_SDC_HPP_
+#define _SPHERE_DATA_CTX_SDC_HPP_
+
+#include <sweet/sphere/SphereData_Spectral.hpp>
+#include <sweet/sphere/SphereHelpers_Diagnostics.hpp>
+#include <sweet/sphere/SphereOperators_SphereData.hpp>
+#include <vector>
+#include <sweet/SimulationVariables.hpp>
+#include "../libpfasst_interface/LevelSingleton.hpp"
+
+#include "../swe_sphere_timeintegrators/SWE_Sphere_TS_ln_erk.hpp"
+
+// Class containing the context necessary to evaluate the right-hand sides
+// Currently only contains a pointer to the LevelSingleton and the SimulationVariables object
+
+class SphereDataCtxSDC {
+
+public:
+
+    // Constructor
+    SphereDataCtxSDC(
+        SimulationVariables *i_simVars,
+        LevelSingleton *i_singleton,
+        int* i_nnodes
+        ) 
+        : simVars(i_simVars), levelSingleton(i_singleton)
+    {
+        int rank   = 0;
+        int nprocs = 0;
+        
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+        
+        if (!simVars)
+        {
+            SWEETError("SphereDataCtx: simVars pointer is NULL!");
+        }
+        
+        if (!levelSingleton)
+        {
+            SWEETError("SphereDataCtx: levelSingleton pointer is NULL!");
+        }
+        
+        // initialize the ln_erk time stepper
+        timestepper_ln_erk = new SWE_Sphere_TS_ln_erk(*simVars, levelSingleton->op);
+
+        // this is never used but this makes clear that with niters=1,
+        // we're actually just calling ERK1
+        timestepper_ln_erk->setup(1);
+    
+        // initialize the residuals
+        residuals.resize(nprocs,std::vector<double>(0,0.));
+
+        // initialize the diagnostics object
+        sphereDiagnostics = new SphereHelpers_Diagnostics(
+                            &(levelSingleton->dataConfig),
+                            *simVars,
+                            0
+                            );
+    }
+
+    // Destructor
+    ~SphereDataCtxSDC() 
+    {
+        delete timestepper_ln_erk;
+        delete sphereDiagnostics;
+    }
+
+    // Getter for the sphere data configuration
+    SphereData_Config* get_sphere_data_config() const 
+    {
+        return &(levelSingleton->dataConfig);
+    }
+
+    // Getter for the sphere data configuration
+    BenchmarksSphereSWE* get_swe_benchmark() const 
+    {
+        return &(levelSingleton->benchmarks);
+    }
+
+    // Getter for the sphere data configuration with no dealiasing
+    SphereData_Config* get_sphere_data_config_nodealiasing() const 
+    {
+        return &(levelSingleton->dataConfigNoDealiasing);
+    }
+
+    // Getter for the sphere data operators
+    SphereOperators_SphereData* get_sphere_operators() const
+    {
+        return &(levelSingleton->op);
+    }
+
+    // Getter for the sphere data operators with no dealiasing
+    SphereOperators_SphereData* get_sphere_operators_nodealiasing() const
+    {
+        return &(levelSingleton->opNoDealiasing);
+    }
+
+    // Getter for the sphere diagnostics
+    SphereHelpers_Diagnostics* get_sphere_diagnostics() 
+    {
+        return sphereDiagnostics;
+    }
+
+    // Getter for the explicit timestepper
+    SWE_Sphere_TS_ln_erk* get_ln_erk_timestepper() const
+    {
+        return timestepper_ln_erk;
+    }
+
+    // Getter for the simulationVariables object
+    SimulationVariables* get_simulation_variables() const 
+    { 
+        return simVars;
+    }
+
+    // Getter for the number of levels
+    int get_number_of_levels() const 
+    {
+        return 1;
+    }
+	      
+    // Save the physical invariants
+    void save_physical_invariants(
+                    int i_niter
+                    ) 
+    {
+        time.push_back(simVars->timecontrol.current_timestep_size * i_niter);
+        mass.push_back(simVars->diag.total_mass);
+        energy.push_back(simVars->diag.total_energy);
+        potentialEnstrophy.push_back(simVars->diag.total_potential_enstrophy);
+    }
+
+    // Getters for the time and invariants vectors
+    const std::vector<double>& get_time()                const { return time; }
+    const std::vector<double>& get_mass()                const { return mass; }
+    const std::vector<double>& get_energy()              const { return energy; }
+    const std::vector<double>& get_potential_enstrophy() const { return potentialEnstrophy; }
+
+    // Getters for the residuals
+    const std::vector<std::vector<double>>& get_residuals() const { return residuals; }
+    std::vector<std::vector<double>>&       get_residuals()       { return residuals; }
+    
+protected:
+
+    // Pointer to the SimulationVariables object
+    SimulationVariables *simVars;
+
+    // Pointer to the LevelSingleton object
+    LevelSingleton *levelSingleton;
+
+    // Pointer to the ln_erk timestepper
+    SWE_Sphere_TS_ln_erk* timestepper_ln_erk;
+
+    // Saved Residuals for each processor
+    std::vector<std::vector<double>> residuals;
+
+    // Diagnostics (mass, energy, enstrophy)
+    SphereHelpers_Diagnostics* sphereDiagnostics;
+
+    // Some constructors and operator= are disabled
+    SphereDataCtxSDC() {};
+    SphereDataCtxSDC(const SphereDataCtxSDC&);
+    SphereDataCtxSDC& operator=(const SphereDataCtxSDC&);
+    
+    // Vectors used for plotting
+    std::vector<double> time;
+    std::vector<double> mass;
+    std::vector<double> energy;
+    std::vector<double> potentialEnstrophy;
+};
+
+#endif // _SPHERE_DATA_CTX_SDC_HPP_

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/cencap.cpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/cencap.cpp
@@ -1,0 +1,236 @@
+#include <iomanip>
+#include <cstddef>
+#include "cencap.hpp"
+
+extern "C"
+{
+/*
+    "Encap" functions called from Fortran to manipulate SphereDataSpectral
+ */
+
+// instantiates and returns the sweet data encapsulated object
+void c_sweet_data_create(
+		SphereDataCtxSDC *i_ctx,
+		int             i_level,
+		SphereDataVars **o_Y,
+		int            *o_size
+)
+{
+	SphereData_Config *Y_config = i_ctx->get_sphere_data_config();
+
+	// create the SphereDataVars object
+	*o_Y  = new SphereDataVars(
+			Y_config,
+			i_level
+	);
+
+	SphereData_Spectral& phi_pert  = (*o_Y)->get_phi_pert();
+	SphereData_Spectral& vrt = (*o_Y)->get_vrt();
+	SphereData_Spectral& div  = (*o_Y)->get_div();
+
+	// initialize the SphereDataSpectral vectors
+	phi_pert.spectral_set_zero();
+	vrt.spectral_set_zero();
+	div.spectral_set_zero();
+
+	// return the size of the number of elements
+	*o_size = 2*(phi_pert.sphereDataConfig->spectral_array_data_number_of_elements
+			+ vrt.sphereDataConfig->spectral_array_data_number_of_elements
+			+ div.sphereDataConfig->spectral_array_data_number_of_elements);
+}
+
+// calls the destructor of the sweet data encapsulated object
+void c_sweet_data_destroy(
+		SphereDataVars *i_Y
+)
+{
+	delete i_Y; // call the sweet object destructor
+}
+
+// sets the value of the sweet data encapsulated object
+void c_sweet_data_setval(
+		SphereDataVars *io_Y,
+		double i_val
+)
+{
+	SphereData_Spectral& phi_pert  = io_Y->get_phi_pert();
+	SphereData_Spectral& vrt = io_Y->get_vrt();
+	SphereData_Spectral& div  = io_Y->get_div();
+
+
+	phi_pert.spectral_set_zero();
+	vrt.spectral_set_zero();
+	div.spectral_set_zero();
+
+	if (i_val == 0)
+	{
+		// set the SphereDataSpectral vectors to zero in spectral space
+	}
+	else
+	{
+		// set the SphereDataSpectral vectors to i_val in physical space
+		phi_pert.spectral_add_physical_constant(i_val);
+		vrt.spectral_add_physical_constant(i_val);
+		div.spectral_add_physical_constant(i_val);
+	}
+}
+
+
+// copies i_src into o_dst
+void c_sweet_data_copy(SphereDataVars *i_src,
+		SphereDataVars *o_dst)
+{
+	const SphereData_Spectral& phi_pert_src  = i_src->get_phi_pert();
+	const SphereData_Spectral& vrt_src  = i_src->get_vrt();
+	const SphereData_Spectral& div_src  = i_src->get_div();
+
+	SphereData_Spectral&       phi_pert_dst  = o_dst->get_phi_pert();
+	SphereData_Spectral&       vrt_dst  = o_dst->get_vrt();
+	SphereData_Spectral&       div_dst  = o_dst->get_div();
+
+	phi_pert_dst  = phi_pert_src;
+	vrt_dst = vrt_src;
+	div_dst  = div_src;
+}
+
+// computes the norm of the sweet data encapsulated object
+void c_sweet_data_norm(
+		SphereDataVars *i_Y,
+		double *o_val
+)
+{
+	const SphereData_Spectral& phi_pert  = i_Y->get_phi_pert();
+
+	*o_val = phi_pert.toPhys().physical_reduce_max_abs();
+}
+
+// packs all the values contained in the sweet data object into a flat array
+void c_sweet_data_pack(
+		SphereDataVars *io_Y,
+		double **o_flat_data_ptr
+)
+{
+	SphereData_Spectral& phi_pert  = io_Y->get_phi_pert();
+	SphereData_Spectral& vrt  = io_Y->get_vrt();
+	SphereData_Spectral& div  = io_Y->get_div();
+
+
+	// allocate the flat data array
+	const int n_elems = 2*(phi_pert.sphereDataConfig->spectral_array_data_number_of_elements
+			+  vrt.sphereDataConfig->spectral_array_data_number_of_elements
+			+   div.sphereDataConfig->spectral_array_data_number_of_elements);
+	io_Y->allocate_flat_data_array(n_elems);
+	double*& flat_data_array = io_Y->get_flat_data_array();
+
+	int j = 0;
+
+	// real and imaginary parts
+
+	// phi_pert
+	for (int i = 0; i < phi_pert.sphereDataConfig->spectral_array_data_number_of_elements; ++i)
+	{
+		flat_data_array[j++] = phi_pert.spectral_space_data[i].imag();
+		flat_data_array[j++] = phi_pert.spectral_space_data[i].real();
+	}
+
+	// vrt
+	for (int i = 0; i < vrt.sphereDataConfig->spectral_array_data_number_of_elements; ++i)
+	{
+		flat_data_array[j++] = vrt.spectral_space_data[i].imag();
+		flat_data_array[j++] = vrt.spectral_space_data[i].real();
+	}
+
+	// div
+	for (int i = 0; i < div.sphereDataConfig->spectral_array_data_number_of_elements; ++i)
+	{
+		flat_data_array[j++] = div.spectral_space_data[i].imag();
+		flat_data_array[j++] = div.spectral_space_data[i].real();
+	}
+
+	// return the pointer to the array
+	*o_flat_data_ptr = flat_data_array;
+}
+
+
+// unpacks the flat array into the sweet data object
+void c_sweet_data_unpack(
+		double **i_flat_data_ptr,
+		SphereDataVars *o_Y
+)
+{
+	int j = 0;
+
+	// copy the values into physical_space_data array
+
+	// phi_pert
+	SphereData_Spectral& phi_pert = o_Y->get_phi_pert();
+	for (int i = 0; i < phi_pert.sphereDataConfig->spectral_array_data_number_of_elements; ++i)
+	{
+		phi_pert.spectral_space_data[i] = std::complex<double>(
+				i_flat_data_ptr[0][j],
+				i_flat_data_ptr[0][j+1]
+		);
+		j += 2;
+	}
+
+	// vrt
+	SphereData_Spectral& vrt = o_Y->get_vrt();
+	for (int i = 0; i < vrt.sphereDataConfig->spectral_array_data_number_of_elements; ++i)
+	{
+		vrt.spectral_space_data[i] = std::complex<double>(
+				i_flat_data_ptr[0][j],
+				i_flat_data_ptr[0][j+1]
+		);
+		j += 2;
+	}
+
+	// div
+	SphereData_Spectral& div = o_Y->get_div();
+	for (int i = 0; i < div.sphereDataConfig->spectral_array_data_number_of_elements; ++i)
+	{
+		div.spectral_space_data[i] = std::complex<double>(
+				i_flat_data_ptr[0][j],
+				i_flat_data_ptr[0][j+1]
+		);
+		j += 2;
+	}
+}
+
+
+// computes io_Y = i_a * i_X + io_Y
+void c_sweet_data_saxpy(
+		double i_a,
+		SphereDataVars *i_X,
+		SphereDataVars *io_Y
+)
+{
+	const SphereData_Spectral& phi_pert_x  = i_X->get_phi_pert();
+	const SphereData_Spectral& vrt_x = i_X->get_vrt();
+	const SphereData_Spectral& div_x  = i_X->get_div();
+
+	SphereData_Spectral&       phi_pert_y  = io_Y->get_phi_pert();
+	SphereData_Spectral&       vrt_y = io_Y->get_vrt();
+	SphereData_Spectral&       div_y  = io_Y->get_div();
+
+	phi_pert_y  = i_a * phi_pert_x  + phi_pert_y;
+	vrt_y = i_a * vrt_x + vrt_y;
+	div_y  = i_a * div_x  + div_y;
+
+}
+
+// prints the data to the terminal
+void c_sweet_data_eprint(
+		SphereDataVars *i_Y
+)
+{
+	const SphereData_Spectral& phi_pert  = i_Y->get_phi_pert();
+	const SphereData_Spectral& vrt = i_Y->get_vrt();
+	const SphereData_Spectral& div  = i_Y->get_div();
+
+	phi_pert.toPhys().physical_print();
+	vrt.toPhys().physical_print();
+	div.toPhys().physical_print();
+
+}
+}
+

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/cencap.hpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/cencap.hpp
@@ -1,0 +1,70 @@
+#ifndef _CENCAP_HPP_
+#define _CENCAP_HPP_
+
+#include <iomanip>
+#include "../libpfasst_interface/SphereDataVars.hpp"
+#include "SphereDataCtxSDC.hpp"
+
+/*
+  "Encap" functions called from Fortran to manipulate SphereData
+*/
+
+
+extern "C"
+{
+  // instantiates and returns the sweet data encapsulated object
+  void c_sweet_data_create(
+			   SphereDataCtxSDC *i_ctx, 
+			   int i_level,
+			   SphereDataVars **o_Y, 
+			   int *o_size
+			   );
+
+  // calls the destructor of the sweet data encapsulated object
+  void c_sweet_data_destroy(
+			    SphereDataVars *i_Y
+			    );
+
+  // sets the value of the sweet data encapsulated object
+  void c_sweet_data_setval(
+			   SphereDataVars *io_Y,  
+			   double i_val
+			   );
+
+  // copies i_src into o_dst
+  void c_sweet_data_copy(
+			 SphereDataVars *i_src,    
+			 SphereDataVars *o_dst
+			 );
+
+  // computes the norm of the sweet data encapsulated object
+  void c_sweet_data_norm(
+			 SphereDataVars *io_Y,     
+			 double* o_val
+			 );
+
+  // packs all the values contained in the sweet data object into a flat array
+  void c_sweet_data_pack(
+			 SphereDataVars *io_Y,
+			 double** o_flat_data_ptr
+			 );
+  // unpacks the flat array into the sweet data object 
+  void c_sweet_data_unpack(
+			   double** i_flat_data_ptr,
+			   SphereDataVars *io_Y
+			   );
+  
+  // computes io_Y = i_a * i_X + io_Y
+  void c_sweet_data_saxpy(
+			  double i_a,          
+			  SphereDataVars *i_X,
+			  SphereDataVars *io_Y      
+			  );
+
+  // prints the data to the terminal
+  void c_sweet_data_eprint(
+			   SphereDataVars *i_Y
+			   );
+}
+
+#endif

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.cpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.cpp
@@ -3,18 +3,15 @@
 #include <string>
 
 #include <sweet/SimulationVariables.hpp>
-#include "../swe_sphere_timeintegrators/SWE_Sphere_TS_l_irk.hpp"
-#include "../swe_sphere_timeintegrators/SWE_Sphere_TS_lg_irk.hpp"
-#include "ceval.hpp"
-
-#include "../swe_sphere_benchmarks/BenchmarksSphereSWE.hpp"
-
-#include "cencap.hpp"
-
 #include <sweet/sphere/SphereData_Spectral.hpp>
 #include <sweet/sphere/SphereOperators_SphereData.hpp>
+
+#include "../swe_sphere_benchmarks/BenchmarksSphereSWE.hpp"
 #include "../swe_sphere_timeintegrators/SWE_Sphere_TS_lg_erk_lc_n_erk.hpp"
 #include "../swe_sphere_timeintegrators/SWE_Sphere_TS_lg_irk.hpp"
+
+#include "ceval.hpp"
+#include "cencap.hpp"
 
 
 /**

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.cpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.cpp
@@ -303,7 +303,6 @@ void ccomp_f2(
 	// get the time step parameters
 	SimulationVariables* simVars = i_ctx->get_simulation_variables();
 
-	// set y = rhs, f = 0.0
 	SphereData_Spectral& phi_pert_Y = io_Y->get_phi_pert();
 	SphereData_Spectral& vrt_Y = io_Y->get_vrt();
 	SphereData_Spectral& div_Y = io_Y->get_div();
@@ -317,6 +316,14 @@ void ccomp_f2(
 	phi_pert_Y = phi_pert_Rhs;
 	vrt_Y = vrt_Rhs;
 	div_Y = div_Rhs;
+
+	if (i_dt == 0)
+	{
+		// quadrature weight is zero -> return trivial solution
+		// y = rhs (already done), f = 0.0
+		c_sweet_data_setval(o_F2, 0.0);
+		return;
+	}
 
 	SWE_Sphere_TS_lg_irk* timestepper = i_ctx->get_lg_irk_timestepper();
 	// solve the implicit system using the Helmholtz solver

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.cpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.cpp
@@ -1,0 +1,320 @@
+#include <iomanip>
+#include <math.h>
+#include <string>
+
+#include <sweet/SimulationVariables.hpp>
+#include "../swe_sphere_timeintegrators/SWE_Sphere_TS_l_irk.hpp"
+#include "../swe_sphere_timeintegrators/SWE_Sphere_TS_lg_irk.hpp"
+#include "ceval.hpp"
+
+#include "../swe_sphere_benchmarks/BenchmarksSphereSWE.hpp"
+
+#include "cencap.hpp"
+
+#include <sweet/sphere/SphereData_Spectral.hpp>
+#include <sweet/sphere/SphereOperators_SphereData.hpp>
+#include "../swe_sphere_timeintegrators/SWE_Sphere_TS_ln_erk.hpp"
+
+
+/**
+ * Write data to file and return string of file name
+ */
+std::string write_file(
+		SphereDataCtxSDC  &i_ctx,
+		const SphereData_Spectral &i_sphereData,
+		const char* i_name	///< name of output variable
+)
+{
+	char buffer[1024];
+
+	// get the pointer to the Simulation Variables object
+	SimulationVariables* simVars = i_ctx.get_simulation_variables();
+
+	// create copy
+	SphereData_Spectral sphereData(i_sphereData);
+
+	// Write the data into the file
+	const char* filename_template = simVars->iodata.output_file_name.c_str();
+	sprintf(buffer,
+			filename_template,
+			i_name,
+			simVars->timecontrol.current_simulation_time*simVars->iodata.output_time_scale);
+    sphereData.file_write_binary_spectral(buffer);
+
+	return buffer;
+}
+
+
+/**
+ *  Write the spectrum to file and return string of file name
+ **/
+std::string write_spectrum_to_file(
+		SphereDataCtxSDC &i_ctx,
+		const SphereData_Spectral &i_sphereData,
+		const char* i_name
+)
+{
+	char buffer[1024];
+
+	// get the pointer to the Simulation Variables object
+	SimulationVariables* simVars = i_ctx.get_simulation_variables();
+
+	// create copy
+	SphereData_Spectral sphereData(i_sphereData);
+
+	// Write the spectrum into the file
+	const char* filename_template = simVars->iodata.output_file_name.c_str();
+	sprintf(buffer,
+			filename_template,
+			i_name,
+            simVars->timecontrol.current_simulation_time*simVars->iodata.output_time_scale);
+	sphereData.spectrum_file_write(buffer);
+
+	return buffer;
+}
+
+
+extern "C"
+{
+// initialization of the variables (initial condition)
+void cinitial(
+		SphereDataCtxSDC *i_ctx, 
+		double i_t,
+		double i_dt,
+		SphereDataVars *o_Y
+)
+{
+	int rank = 0;
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+	SphereData_Spectral& phi_pert_Y  = o_Y->get_phi_pert();
+	SphereData_Spectral& vrt_Y = o_Y->get_vrt();
+	SphereData_Spectral& div_Y  = o_Y->get_div();
+
+	// get the SimulationVariables object from context
+	SimulationVariables* simVars(i_ctx->get_simulation_variables());
+
+	if (simVars->benchmark.use_topography)
+		write_file(*i_ctx, simVars->benchmark.h_topo,  "prog_h_topo");
+	
+	BenchmarksSphereSWE *benchmarks = i_ctx->get_swe_benchmark();
+
+	if (simVars->benchmark.setup_dealiased)
+	{
+		// use dealiased physical space for setup
+		// get operator for this level
+		SphereOperators_SphereData* op = i_ctx->get_sphere_operators();
+		benchmarks->setup(*simVars, *op);
+		benchmarks->master->get_initial_state(phi_pert_Y, vrt_Y, div_Y);
+	}
+	else
+	{
+		// this is not the default since noone uses it
+		// use reduced physical space for setup to avoid spurious modes
+
+		// get the configuration for this level
+		SphereData_Config* data_config_nodealiasing = i_ctx->get_sphere_data_config_nodealiasing();
+		SphereData_Spectral phi_pert_Y_nodealiasing(data_config_nodealiasing);
+		SphereData_Spectral vrt_Y_nodealiasing(data_config_nodealiasing);
+		SphereData_Spectral div_Y_nodealiasing(data_config_nodealiasing);
+
+		SphereOperators_SphereData* op_nodealiasing = i_ctx->get_sphere_operators_nodealiasing();
+
+		benchmarks->setup(*simVars, *op_nodealiasing);
+		benchmarks->master->get_initial_state(phi_pert_Y_nodealiasing, vrt_Y_nodealiasing, div_Y_nodealiasing);
+
+		phi_pert_Y.load_nodealiasing(phi_pert_Y_nodealiasing);
+		vrt_Y.load_nodealiasing(vrt_Y_nodealiasing);
+		div_Y.load_nodealiasing(div_Y_nodealiasing);
+	}
+
+	// output the configuration
+	simVars->outputConfig();
+
+	if (rank == 0)
+	{
+		write_file(*i_ctx, phi_pert_Y,  "prog_phi_pert");
+		write_file(*i_ctx, vrt_Y, "prog_vrt");
+		write_file(*i_ctx, div_Y,  "prog_div");
+		if (simVars->iodata.output_each_sim_seconds < 0) {
+		    // only write output at start and end
+		    simVars->iodata.output_next_sim_seconds = simVars->timecontrol.max_simulation_time;
+		}
+		else if (simVars->iodata.output_each_sim_seconds > 0) {
+		    // write output every output_each_sim_seconds
+		    // next output time is thus equal to output_each_sim_seconds
+		    simVars->iodata.output_next_sim_seconds = simVars->iodata.output_each_sim_seconds;
+		}
+		else {
+		    // output at every time step
+		    simVars->iodata.output_next_sim_seconds = simVars->timecontrol.current_timestep_size;
+		}
+	}
+
+	SphereData_Spectral phi_pert_Y_init(phi_pert_Y);
+	SphereData_Spectral phi_pert_Y_final(phi_pert_Y);
+	phi_pert_Y_init -= phi_pert_Y_final;
+
+	SphereData_Spectral div_Y_init(div_Y);
+	SphereData_Spectral div_Y_final(div_Y);
+	div_Y_init -= div_Y_final;
+
+	SphereData_Spectral vrt_Y_init(vrt_Y);
+	SphereData_Spectral vrt_Y_final(vrt_Y);
+	vrt_Y_init -= vrt_Y_final;
+
+}
+
+// finalizes the time step when libpfasst is done
+// currently does nothing else than outputting the solution
+void cfinal(
+		SphereDataCtxSDC *i_ctx,
+		SphereDataVars *i_Y,
+		int i_nnodes,
+		int i_niters
+)
+{
+	int rank   = 0;
+	int nprocs = 0;
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+	MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+
+	const SphereData_Spectral& phi_pert_Y  = i_Y->get_phi_pert();
+	const SphereData_Spectral& vrt_Y = i_Y->get_vrt();
+	const SphereData_Spectral& div_Y  = i_Y->get_div();
+
+	const int& level_id = i_Y->get_level();
+
+	// get the SimulationVariables object from context
+	SimulationVariables* simVars(i_ctx->get_simulation_variables());
+
+	SphereData_Spectral phi_pert_Y_init(phi_pert_Y);
+	SphereData_Spectral phi_pert_Y_final(phi_pert_Y);
+	phi_pert_Y_init -= phi_pert_Y_final;
+	
+	SphereData_Spectral div_Y_init(div_Y);
+	SphereData_Spectral div_Y_final(div_Y);
+	div_Y_init -= div_Y_final;
+
+	SphereData_Spectral vrt_Y_init(vrt_Y);
+	SphereData_Spectral vrt_Y_final(vrt_Y);
+	vrt_Y_init -= vrt_Y_final;
+
+	if (level_id == simVars->libpfasst.nlevels-1) 
+	{
+		if (nprocs == 1)
+		{
+			std::string filename = "prog_phi_pert";
+			write_file(*i_ctx, phi_pert_Y, filename.c_str());
+
+			filename = "prog_vrt";
+			write_file(*i_ctx, vrt_Y, filename.c_str());
+
+			filename = "prog_div";
+			write_file(*i_ctx, div_Y, filename.c_str());
+
+		}
+		else if (rank == 0)
+		{
+			std::string filename = "prog_phi_pert_nprocs_"+std::to_string(nprocs);
+			write_file(*i_ctx, phi_pert_Y, filename.c_str());
+
+			filename = "prog_vrt_nprocs_"+std::to_string(nprocs);
+			write_file(*i_ctx, vrt_Y, filename.c_str());
+
+			filename = "prog_div_nprocs_"+std::to_string(nprocs);
+			write_file(*i_ctx, div_Y, filename.c_str());
+		}
+	}
+}
+
+// evaluates the explicit (nonlinear) piece
+void ceval(SphereDataVars *i_Y,
+		double i_t,
+		SphereDataCtxSDC *i_ctx,
+		SphereDataVars *o_F1
+)
+{
+	const SphereData_Spectral& phi_pert_Y  = i_Y->get_phi_pert();
+	const SphereData_Spectral& vrt_Y = i_Y->get_vrt();
+	const SphereData_Spectral& div_Y  = i_Y->get_div();
+
+	SphereData_Spectral& phi_pert_F1  = o_F1->get_phi_pert();
+	SphereData_Spectral& vrt_F1 = o_F1->get_vrt();
+	SphereData_Spectral& div_F1  = o_F1->get_div();
+
+	// get the time step parameters
+	SimulationVariables* simVars = i_ctx->get_simulation_variables();
+
+	// use ERK timestepper for all terms
+	SWE_Sphere_TS_ln_erk* timestepper = i_ctx->get_ln_erk_timestepper();
+	// compute the explicit nonlinear right-hand side
+	timestepper->euler_timestep_update_pert(
+			phi_pert_Y,
+			vrt_Y,
+			div_Y,
+			phi_pert_F1,
+			vrt_F1,
+			div_F1,
+			simVars->timecontrol.current_simulation_time
+	);
+}
+
+
+void ccomp (
+		SphereDataVars *io_Y,
+		double i_t,
+		double i_dt,
+		SphereDataVars *i_Rhs,
+		SphereDataCtxSDC *i_ctx,
+		SphereDataVars *o_F2
+)
+{
+	// set y = rhs, f = 0.0
+	SphereData_Spectral& phi_pert_Y  = io_Y->get_phi_pert();
+	SphereData_Spectral& vrt_Y = io_Y->get_vrt();
+	SphereData_Spectral& div_Y  = io_Y->get_div();
+
+	const SphereData_Spectral& phi_pert_Rhs  = i_Rhs->get_phi_pert();
+	const SphereData_Spectral& vrt_Rhs = i_Rhs->get_vrt();
+	const SphereData_Spectral& div_Rhs  = i_Rhs->get_div();
+
+	phi_pert_Y = phi_pert_Rhs;
+	vrt_Y = vrt_Rhs;
+	div_Y = div_Rhs;
+
+	c_sweet_data_setval(o_F2, 0.0);
+
+	return;
+
+}
+
+
+// applies artificial diffusion to the system
+void cfinalize(
+		SphereDataVars *io_Y,
+		double i_t,
+		double i_dt,
+		SphereDataCtxSDC *i_ctx
+)
+{
+	// get the simulation variables
+	SimulationVariables* simVars = i_ctx->get_simulation_variables();
+
+	if (simVars->sim.viscosity == 0)
+		return;
+
+	SphereData_Spectral& phi_pert_Y  = io_Y->get_phi_pert();
+	SphereData_Spectral& vrt_Y = io_Y->get_vrt();
+	SphereData_Spectral& div_Y  = io_Y->get_div();
+
+	const double scalar = simVars->sim.viscosity*i_dt;
+	const double r      = simVars->sim.sphere_radius;
+
+	phi_pert_Y  = phi_pert_Y.spectral_solve_helmholtz(1.0,  -scalar, r);
+	vrt_Y = vrt_Y.spectral_solve_helmholtz(1.0, -scalar, r);
+	div_Y  = div_Y.spectral_solve_helmholtz(1.0,  -scalar, r);
+}
+
+
+}

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.cpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.cpp
@@ -294,7 +294,7 @@ void ceval_f2(SphereDataVars *i_Y,
 void ccomp_f2(
 		SphereDataVars *io_Y,
 		double i_t,
-		double i_dt,
+		double i_dtq,
 		SphereDataVars *i_Rhs,
 		SphereDataCtxSDC *i_ctx,
 		SphereDataVars *o_F2
@@ -317,7 +317,7 @@ void ccomp_f2(
 	vrt_Y = vrt_Rhs;
 	div_Y = div_Rhs;
 
-	if (i_dt == 0)
+	if (i_dtq == 0)
 	{
 		// quadrature weight is zero -> return trivial solution
 		// y = rhs (already done), f = 0.0
@@ -331,7 +331,7 @@ void ccomp_f2(
 					phi_pert_Y,
 					vrt_Y,
 					div_Y,
-					i_dt,
+					i_dtq,
 					simVars->timecontrol.max_simulation_time
 					);
 
@@ -339,39 +339,12 @@ void ccomp_f2(
 	SphereData_Spectral& vrt_F2 = o_F2->get_vrt();
 	SphereData_Spectral& div_F2  = o_F2->get_div();
 	
-	phi_pert_F2 = (phi_pert_Y - phi_pert_Rhs) / i_dt;
-	vrt_F2      = (vrt_Y - vrt_Rhs) / i_dt;
-	div_F2      = (div_Y - div_Rhs) / i_dt;
+	phi_pert_F2 = (phi_pert_Y - phi_pert_Rhs) / i_dtq;
+	vrt_F2      = (vrt_Y - vrt_Rhs) / i_dtq;
+	div_F2      = (div_Y - div_Rhs) / i_dtq;
 
 	return;
 
-}
-
-
-// applies artificial diffusion to the system
-void cfinalize(
-		SphereDataVars *io_Y,
-		double i_t,
-		double i_dt,
-		SphereDataCtxSDC *i_ctx
-)
-{
-	// get the simulation variables
-	SimulationVariables* simVars = i_ctx->get_simulation_variables();
-
-	if (simVars->sim.viscosity == 0)
-		return;
-
-	SphereData_Spectral& phi_pert_Y  = io_Y->get_phi_pert();
-	SphereData_Spectral& vrt_Y = io_Y->get_vrt();
-	SphereData_Spectral& div_Y  = io_Y->get_div();
-
-	const double scalar = simVars->sim.viscosity*i_dt;
-	const double r      = simVars->sim.sphere_radius;
-
-	phi_pert_Y  = phi_pert_Y.spectral_solve_helmholtz(1.0,  -scalar, r);
-	vrt_Y = vrt_Y.spectral_solve_helmholtz(1.0, -scalar, r);
-	div_Y  = div_Y.spectral_solve_helmholtz(1.0,  -scalar, r);
 }
 
 

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.hpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.hpp
@@ -56,17 +56,11 @@ extern "C"
   void ccomp_f2(
 		 SphereDataVars *io_Y, 
 		 double i_t, 
-		 double i_dt, 
+		 double i_dtq, 
 		 SphereDataVars *i_Rhs, 
 		 SphereDataCtxSDC *i_ctx,
 		 SphereDataVars *o_F2 
 		 );
-
-  // applies artificial diffusion
-  void cfinalize (SphereDataVars *io_Y,
-		  double i_t,
-		  double i_dt,
-		  SphereDataCtxSDC *i_ctx);
   
 }
 

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.hpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.hpp
@@ -36,16 +36,24 @@ extern "C"
 	      int i_niters
 	      );
 
-  // evaluates the explicit piece
-  void ceval(
+  // evaluates the explicit nonlinear piece
+  void ceval_f1(
 		SphereDataVars *i_Y, 
 		double i_t, 
 		SphereDataCtxSDC *i_ctx,
 		SphereDataVars *o_F1
 		);
 
-  // solves the first implicit system
-  void ccomp (
+  // evaluates the implicit linear piece
+  void ceval_f2(
+		SphereDataVars *i_Y, 
+		double i_t, 
+		SphereDataCtxSDC *i_ctx,
+		SphereDataVars *o_F1
+		);
+
+  // solves the implicit system
+  void ccomp_f2(
 		 SphereDataVars *io_Y, 
 		 double i_t, 
 		 double i_dt, 

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.hpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/ceval.hpp
@@ -1,0 +1,65 @@
+#ifndef _CEVAL_HPP_
+#define _CEVAL_HPP_
+
+#include "../libpfasst_interface/SphereDataVars.hpp"
+#include "SphereDataCtxSDC.hpp"
+
+/**
+ * Write file to data and return string of file name
+ */
+
+std::string write_file(
+		       SphereDataCtxSDC  &i_ctx,
+		       const SphereData_Spectral &i_sphereData,
+		       const char* i_name	///< name of output variable
+		       );
+
+/*
+  Right-hand-side functions called from Fortran 
+*/
+
+extern "C"
+{
+  // initialization of the variables (initial condition)
+  void cinitial(
+		SphereDataCtxSDC *i_ctx,
+		double i_t,
+		double i_dt, 
+		SphereDataVars *o_Y
+		);
+
+  // finalizes the time step when libpfasst is done 
+  void cfinal(
+	      SphereDataCtxSDC *i_ctx, 
+	      SphereDataVars *i_Y,
+	      int i_nnodes,
+	      int i_niters
+	      );
+
+  // evaluates the explicit piece
+  void ceval(
+		SphereDataVars *i_Y, 
+		double i_t, 
+		SphereDataCtxSDC *i_ctx,
+		SphereDataVars *o_F1
+		);
+
+  // solves the first implicit system
+  void ccomp (
+		 SphereDataVars *io_Y, 
+		 double i_t, 
+		 double i_dt, 
+		 SphereDataVars *i_Rhs, 
+		 SphereDataCtxSDC *i_ctx,
+		 SphereDataVars *o_F2 
+		 );
+
+  // applies artificial diffusion
+  void cfinalize (SphereDataVars *io_Y,
+		  double i_t,
+		  double i_dt,
+		  SphereDataCtxSDC *i_ctx);
+  
+}
+
+#endif

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/chooks.cpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/chooks.cpp
@@ -1,0 +1,194 @@
+#include <mpi.h>
+#include "../libpfasst_interface/SphereDataVars.hpp"
+#include "SphereDataCtxSDC.hpp"
+#include "ceval.hpp"
+
+extern "C"
+{
+    bool timestep_check_output(SphereDataCtxSDC *i_ctx,
+                               int i_current_iter,
+                               int i_niters)
+    {
+        if (i_current_iter < i_niters) {
+            // TODO: make this controllable via command line argument
+            return false;
+        }
+
+        // get the simulation variables
+        SimulationVariables* simVars = i_ctx->get_simulation_variables();
+
+        if (simVars->iodata.output_each_sim_seconds < 0) {
+            // write no output between start and end of simulation
+            return false;
+        }
+
+        if (simVars->iodata.output_each_sim_seconds == 0) {
+            // write output at every time step
+            return true;
+        }
+
+        if (simVars->timecontrol.current_simulation_time < simVars->iodata.output_next_sim_seconds) {
+            // we have not reached the next output time step
+            return false;
+        }
+
+        if (simVars->timecontrol.max_simulation_time - simVars->timecontrol.current_simulation_time < 1e-3) {
+            // do not write output if final time step is reached
+            // (output will be written in cfinal anyways)
+            return false;
+        }
+
+        // we have reached the next output time step
+        return true;
+    }
+
+    void cecho_error(SphereData_Spectral* sd,
+                     int step)
+    {
+      // not implemented
+    }
+
+    void cecho_residual(SphereDataCtxSDC *i_ctx,
+                        double i_norm,
+                        int i_current_proc)
+    {
+        // get the residual vector
+        std::vector<std::vector<double> >& residuals = i_ctx->get_residuals();
+
+        // save the residual
+        residuals[i_current_proc].push_back(i_norm);
+    }
+
+    void cecho_output_invariants(SphereDataCtxSDC *i_ctx,
+                                 SphereDataVars *i_Y,
+                                 int i_current_proc,
+                                 int i_current_step,
+                                 int i_current_iter,
+                                 int i_nnodes,
+                                 int i_niters
+                                 )
+    {
+        const SphereData_Spectral& phi_pert_Y  = i_Y->get_phi_pert();
+        const SphereData_Spectral& vrt_Y = i_Y->get_vrt();
+        const SphereData_Spectral& div_Y  = i_Y->get_div();
+
+        // get the simulation variables
+        SimulationVariables* simVars         = i_ctx->get_simulation_variables();
+
+        // get the SphereDiagnostics object from context
+        SphereHelpers_Diagnostics* sphereDiagnostics = i_ctx->get_sphere_diagnostics();
+
+        // get the SphereOperators object from context
+        SphereOperators_SphereData* sphereOperators     = i_ctx->get_sphere_operators();
+
+        // compute the invariants
+        sphereDiagnostics->update_phi_vrt_div_2_mass_energy_enstrophy(
+                                       *sphereOperators,
+                                       phi_pert_Y,
+                                       vrt_Y,
+                                       div_Y,
+                                       *simVars
+                                       );
+
+        std::cout << std::setprecision(20)
+              << "mass = " << simVars->diag.total_mass
+              << " energy = " << simVars->diag.total_energy
+              << " potential_enstrophy = " << simVars->diag.total_potential_enstrophy
+              << std::endl;
+
+        // save the invariants for plotting at the end
+        i_ctx->save_physical_invariants(i_current_step);
+    }
+
+    void cecho_output_jump(SphereDataCtxSDC *i_ctx,
+                           SphereDataVars *i_Y,
+                           int i_current_proc,
+                           int i_current_step,
+                           int i_current_iter,
+                           int i_nnodes,
+                           int i_niters
+                           )
+    {
+        const SphereData_Spectral& phi_pert_Y  = i_Y->get_phi_pert();
+        const SphereData_Spectral& vrt_Y = i_Y->get_vrt();
+        const SphereData_Spectral& div_Y  = i_Y->get_div();
+
+        // get the pointer to the Simulation Variables object
+        SimulationVariables* simVars = i_ctx->get_simulation_variables();
+        simVars->timecontrol.current_timestep_nr = i_current_step + 1;
+        auto current_dt = simVars->timecontrol.current_timestep_size;
+        simVars->timecontrol.current_simulation_time = (i_current_step + 1) * current_dt;
+
+        // write the data to file
+        std::string filename = "prog_jump_phi_pert_current_proc_"+std::to_string(i_current_proc)
+                                    +"_current_iter_"+std::to_string(i_current_iter)
+                                    +"_nnodes_"      +std::to_string(i_nnodes)
+                                    +"_niters_"      +std::to_string(i_niters);
+        write_file(*i_ctx, phi_pert_Y, filename.c_str());
+
+        filename = "prog_jump_vrt_current_proc_"+std::to_string(i_current_proc)
+                        +"_current_iter_"+std::to_string(i_current_iter)
+                        +"_nnodes_"      +std::to_string(i_nnodes)
+                        +"_niters_"      +std::to_string(i_niters);
+        write_file(*i_ctx, vrt_Y, filename.c_str());
+
+        filename = "prog_jump_div_current_proc_"+std::to_string(i_current_proc)
+                        +"_current_iter_"+std::to_string(i_current_iter)
+                        +"_nnodes_"      +std::to_string(i_nnodes)
+                        +"_niters_"      +std::to_string(i_niters);
+        write_file(*i_ctx, div_Y, filename.c_str());
+    }
+
+
+
+    void cecho_output_solution(SphereDataCtxSDC *i_ctx,
+                               SphereDataVars *i_Y,
+                               int i_current_proc,
+                               int i_current_step,
+                               int i_current_iter,
+                               int i_nnodes,
+                               int i_niters
+                               )
+    {
+        // get the pointer to the Simulation Variables object
+        SimulationVariables* simVars = i_ctx->get_simulation_variables();
+
+        // update timecontrol information
+        simVars->timecontrol.current_timestep_nr = i_current_step + 1;
+        auto current_dt = simVars->timecontrol.current_timestep_size;
+        simVars->timecontrol.current_simulation_time = (i_current_step + 1) * current_dt;
+
+        // check if we should write output
+        if (!timestep_check_output(i_ctx, i_current_iter, i_niters)) {
+            return;
+        }
+
+        // update when to write output the next time
+        simVars->iodata.output_next_sim_seconds += simVars->iodata.output_each_sim_seconds;
+
+        const SphereData_Spectral& phi_pert_Y  = i_Y->get_phi_pert();
+        const SphereData_Spectral& vrt_Y = i_Y->get_vrt();
+        const SphereData_Spectral& div_Y  = i_Y->get_div();
+
+        // write the data to file
+        std::string filename = "prog_phi_pert_current_proc_"+std::to_string(i_current_proc)
+                                  +"_current_iter_"+std::to_string(i_current_iter)
+                                  +"_nnodes_"      +std::to_string(i_nnodes)
+                                  +"_niters_"      +std::to_string(i_niters);
+        write_file(*i_ctx, phi_pert_Y, filename.c_str());
+
+        filename = "prog_vrt_current_proc_"+std::to_string(i_current_proc)
+                      +"_current_iter_"+std::to_string(i_current_iter)
+                      +"_nnodes_"      +std::to_string(i_nnodes)
+                      +"_niters_"      +std::to_string(i_niters);
+        write_file(*i_ctx, vrt_Y, filename.c_str());
+
+        filename = "prog_div_current_proc_"+std::to_string(i_current_proc)
+                      +"_current_iter_"+std::to_string(i_current_iter)
+                      +"_nnodes_"      +std::to_string(i_nnodes)
+                      +"_niters_"      +std::to_string(i_niters);
+        write_file(*i_ctx, div_Y, filename.c_str());
+
+    }
+
+}

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/ctransfer.cpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/ctransfer.cpp
@@ -1,0 +1,56 @@
+#include "ctransfer.hpp"
+
+#include "../swe_sphere_benchmarks/BenchmarksSphereSWE.hpp"
+
+#include "cencap.hpp"
+
+
+extern "C"
+{
+  void c_sweet_data_restrict(
+			     SphereDataVars *io_Y_coarse, 
+			     SphereDataVars *i_Y_fine, 
+			     int i_level_coarse,
+			     int i_level_fine, 
+			     SphereDataCtxSDC *i_ctx,
+			     double i_t) 
+  {
+    const SphereData_Spectral& phi_pert_Y_fine  = i_Y_fine->get_phi_pert();
+    const SphereData_Spectral& vrt_Y_fine = i_Y_fine->get_vrt();
+    const SphereData_Spectral& div_Y_fine  = i_Y_fine->get_div();
+
+    SphereData_Spectral& phi_pert_Y_coarse  = io_Y_coarse->get_phi_pert();
+    SphereData_Spectral& vrt_Y_coarse = io_Y_coarse->get_vrt();
+    SphereData_Spectral& div_Y_coarse  = io_Y_coarse->get_div();
+
+    // restrict the fine variables to the coarse grid and copy into the coarse variables
+    phi_pert_Y_coarse  = phi_pert_Y_fine.spectral_returnWithDifferentModes(i_ctx->get_sphere_data_config());
+    vrt_Y_coarse = vrt_Y_fine.spectral_returnWithDifferentModes(i_ctx->get_sphere_data_config());
+    div_Y_coarse  = div_Y_fine.spectral_returnWithDifferentModes(i_ctx->get_sphere_data_config());
+ 
+  }  
+
+  void c_sweet_data_interpolate(
+				SphereDataVars *io_Y_fine, 
+				SphereDataVars *i_Y_coarse, 
+				int i_level_fine,
+				int i_level_coarse,
+				SphereDataCtxSDC *i_ctx,
+				double i_t) 
+  {
+    const SphereData_Spectral& phi_pert_Y_coarse  = i_Y_coarse->get_phi_pert();
+    const SphereData_Spectral& vrt_Y_coarse = i_Y_coarse->get_vrt();
+    const SphereData_Spectral& div_Y_coarse  = i_Y_coarse->get_div();
+  
+    SphereData_Spectral& phi_pert_Y_fine  = io_Y_fine->get_phi_pert();
+    SphereData_Spectral& vrt_Y_fine = io_Y_fine->get_vrt();
+    SphereData_Spectral& div_Y_fine  = io_Y_fine->get_div();
+
+    // interpolate the coarse variables on the fine grid and copy into the coarse variables
+    phi_pert_Y_fine  = phi_pert_Y_coarse.spectral_returnWithDifferentModes(i_ctx->get_sphere_data_config());
+    vrt_Y_fine = vrt_Y_coarse.spectral_returnWithDifferentModes(i_ctx->get_sphere_data_config());
+    div_Y_fine  = div_Y_coarse.spectral_returnWithDifferentModes(i_ctx->get_sphere_data_config());
+
+  }
+}
+

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/ctransfer.hpp
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/ctransfer.hpp
@@ -1,0 +1,29 @@
+#ifndef _CTRANSFER_HPP_
+#define _CTRANSFER_HPP_
+
+#include "../libpfasst_interface/SphereDataVars.hpp"
+#include "SphereDataCtxSDC.hpp"
+
+extern "C"
+{
+  void c_sweet_data_restrict(
+			     SphereDataVars *io_Y_coarse, 
+			     SphereDataVars *i_Y_fine, 
+			     int i_level_coarse,
+			     int i_level_fine, 
+			     SphereDataCtxSDC *i_ctx,
+			     double i_t
+			     );
+
+  void c_sweet_data_interpolate(
+				SphereDataVars *io_Y_fine, 
+				SphereDataVars *i_Y_coarse, 
+				int i_level_fine,
+				int i_level_coarse,
+				SphereDataCtxSDC *i_ctx,
+				double i_t
+				);
+
+}
+
+#endif

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/fencap.f90
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/fencap.f90
@@ -1,0 +1,319 @@
+module encap_module
+    use iso_c_binding 
+    use pf_mod_dtype
+    implicit none
+
+    ! derived factory class for the instantion/destruction of the sweet_data_encap_t object
+
+    type, extends (pf_factory_t) :: sweet_data_factory_t
+        type(c_ptr) :: ctx = c_null_ptr ! c pointer to PlaneDataCtx/SphereDataCtx
+    contains 
+        procedure   :: create_single  => sweet_data_create_single
+        procedure   :: create_array   => sweet_data_create_array 
+        procedure   :: destroy_single => sweet_data_destroy_single
+        procedure   :: destroy_array  => sweet_data_destroy_array
+    end type sweet_data_factory_t
+
+    type, extends (pf_encap_t) :: sweet_data_encap_t
+        type(c_ptr) :: c_sweet_data_ptr = c_null_ptr ! c pointer to PlaneData/SphereData
+        integer     :: data_size ! size of the flat data array
+    contains
+        procedure   :: setval   => sweet_data_setval
+        procedure   :: copy     => sweet_data_copy
+        procedure   :: norm     => sweet_data_norm
+        procedure   :: pack     => sweet_data_pack
+        procedure   :: unpack   => sweet_data_unpack
+        procedure   :: axpy     => sweet_data_saxpy
+        procedure   :: eprint   => sweet_data_eprint
+    end type sweet_data_encap_t
+  
+    interface 
+
+        ! prototypes of the C functions
+
+        subroutine c_sweet_data_create(i_sd_ctx, i_lv, o_sd, o_s) bind(c, name="c_sweet_data_create")
+            use iso_c_binding
+            type(c_ptr), value       :: i_sd_ctx
+            integer,     value       :: i_lv
+            type(c_ptr), intent(out) :: o_sd
+            integer,     intent(out) :: o_s
+        end subroutine c_sweet_data_create
+
+        subroutine c_sweet_data_destroy(io_sd) bind(c, name="c_sweet_data_destroy")
+            use iso_c_binding
+            type(c_ptr), value :: io_sd
+        end subroutine c_sweet_data_destroy
+
+        subroutine c_sweet_data_setval(io_sd, i_val) bind(c, name="c_sweet_data_setval")
+            use iso_c_binding
+            type(c_ptr),    value :: io_sd
+            real(c_double), value :: i_val
+        end subroutine c_sweet_data_setval
+        
+        subroutine c_sweet_data_copy(i_src,o_dst) bind(c, name="c_sweet_data_copy")
+            use iso_c_binding
+            type(c_ptr), value :: i_src, o_dst
+        end subroutine c_sweet_data_copy
+        
+        subroutine c_sweet_data_norm(i_sd, o_val) bind(c, name="c_sweet_data_norm")
+            use iso_c_binding
+            type(c_ptr), value :: i_sd
+            real(c_double)     :: o_val
+        end subroutine c_sweet_data_norm
+
+        subroutine c_sweet_data_pack(io_sd, o_flat_data_ptr) bind(c, name="c_sweet_data_pack")
+            use iso_c_binding
+            type(c_ptr), value       :: io_sd
+            type(c_ptr), intent(out) :: o_flat_data_ptr
+        end subroutine c_sweet_data_pack
+
+        subroutine c_sweet_data_unpack(i_flat_data_ptr, o_sd) bind(c, name="c_sweet_data_unpack")
+            use iso_c_binding
+            type(c_ptr), intent(in) :: i_flat_data_ptr
+            type(c_ptr), value      :: o_sd
+        end subroutine c_sweet_data_unpack
+
+        subroutine c_sweet_data_saxpy(i_a, i_x, io_y) bind(c, name="c_sweet_data_saxpy")
+            use iso_c_binding
+            real(c_double), value :: i_a
+            type(c_ptr),    value :: i_x, io_y
+        end subroutine c_sweet_data_saxpy       
+
+        subroutine c_sweet_data_eprint(i_sd) bind(c, name="c_sweet_data_eprint")
+            use iso_c_binding
+            type(c_ptr), value :: i_sd
+        end subroutine c_sweet_data_eprint
+
+    end interface
+
+contains
+
+
+    ! function used to "cast" the pf_factory_t objects 
+    ! into sweet_data_factory_t objects
+
+    function as_sweet_data_factory(i_factory) result(o_r)
+        class(pf_factory_t), intent(in), target :: i_factory
+        class(sweet_data_factory_t), pointer    :: o_r
+
+        select type(i_factory)
+        type is (sweet_data_factory_t)
+            o_r => i_factory
+        class default
+            stop "TYPE ERROR"
+        end select
+
+    end function as_sweet_data_factory
+
+
+    ! function used to "cast" the pf_encap_t objects 
+    ! into sweet_data_encap_t objects
+     
+    function as_sweet_data_encap(i_encap) result(o_r)
+        class(pf_encap_t), intent(in), target :: i_encap
+        class(sweet_data_encap_t), pointer    :: o_r
+
+        select type(i_encap)
+        type is (sweet_data_encap_t)
+            o_r => i_encap
+        class default
+            stop "TYPE ERROR"
+        end select
+
+    end function as_sweet_data_encap
+    
+
+    ! constructors/destructors of the sweet_data objects 
+    ! PlaneData or SphereData
+
+    subroutine sweet_data_create_single(this, x, level_index, lev_shape)
+        class(sweet_data_factory_t), intent(inout)              :: this
+        class(pf_encap_t),           intent(inout), allocatable :: x
+        integer,                     intent(in   )              :: level_index, lev_shape(:)
+
+        allocate(sweet_data_encap_t::x)
+
+        select type(x)
+        type is (sweet_data_encap_t)
+            call c_sweet_data_create(this%ctx,           &
+                                     level_index-1,      &
+                                     x%c_sweet_data_ptr, &
+                                     x%data_size) ! conversion to C++ indexing
+        class default
+            stop "TYPE ERROR"
+        end select
+
+    end subroutine sweet_data_create_single
+
+
+    subroutine sweet_data_create_array(this, x, n, level_index, lev_shape)
+        class(sweet_data_factory_t), intent(inout)              :: this
+        class(pf_encap_t),           intent(inout), allocatable :: x(:)
+        integer,                     intent(in   )              :: n, level_index, lev_shape(:)
+
+        integer                                                 :: i
+        class(sweet_data_encap_t), pointer                      :: x_ptr
+
+        allocate(sweet_data_encap_t::x(n))    
+
+        do i = 1, n
+            x_ptr => as_sweet_data_encap(x(i))
+            select type(x_ptr)
+            type is (sweet_data_encap_t)
+                call c_sweet_data_create(this%ctx,               &
+                                         level_index-1,          &
+                                         x_ptr%c_sweet_data_ptr, &
+                                         x_ptr%data_size) ! conversion to C++ indexing    
+            class default
+                stop "TYPE ERROR"
+            end select          
+        end do
+
+    end subroutine sweet_data_create_array
+
+  
+    subroutine sweet_data_destroy_single(this, x)
+        class(sweet_data_factory_t), intent(inout)              :: this
+        class(pf_encap_t),           intent(inout), allocatable :: x
+
+        class(sweet_data_encap_t), pointer                      :: x_ptr
+        
+        x_ptr => as_sweet_data_encap(x)
+
+        call c_sweet_data_destroy(x_ptr%c_sweet_data_ptr)
+
+        deallocate(x)
+
+    end subroutine sweet_data_destroy_single
+
+
+    subroutine sweet_data_destroy_array(this, x) !, n, level, kind, nvars, shape)
+        class(sweet_data_factory_t), intent(inout)              :: this
+        class(pf_encap_t),           intent(inout), allocatable :: x(:)
+        !integer,                     intent(in   )              :: n, level, kind, nvars, shape(:)
+
+        class(sweet_data_encap_t), pointer                      :: x_ptr
+        integer                                                 :: i
+
+        select type(x)
+        class is (sweet_data_encap_t)
+            do i = 1, size(x) ! unsure about this --> TODO
+                call c_sweet_data_destroy(x(i)%c_sweet_data_ptr)
+            end do
+        end select 
+        deallocate(x)
+
+    end subroutine sweet_data_destroy_array
+
+
+    ! sweet_data (PlaneData/SphereData) operators
+
+    subroutine sweet_data_setval(this, val, flags)
+        class(sweet_data_encap_t), intent(inout)           :: this
+        real(c_double),            intent(in   )           :: val
+        integer,                   intent(in   ), optional :: flags ! not used here
+
+        call c_sweet_data_setval(this%c_sweet_data_ptr, &
+                                 val)    
+
+    end subroutine sweet_data_setval
+
+  
+    subroutine sweet_data_copy(this, src, flags)
+        class(sweet_data_encap_t), intent(inout)           :: this
+        class(pf_encap_t),         intent(in   )           :: src
+        integer,                   intent(in   ), optional :: flags ! not used here
+
+        class(sweet_data_encap_t), pointer                 :: src_sd_ptr
+
+        src_sd_ptr => as_sweet_data_encap(src)
+
+        call c_sweet_data_copy(src_sd_ptr%c_sweet_data_ptr, &
+                               this%c_sweet_data_ptr)
+
+    end subroutine sweet_data_copy
+        
+    
+    function sweet_data_norm(this, flags) result (norm)
+        class(sweet_data_encap_t), intent(in   ) :: this
+        integer,                   intent(in   ), optional :: flags ! not used here
+        real(c_double)                           :: norm
+
+        call c_sweet_data_norm(this%c_sweet_data_ptr, & 
+                               norm)
+
+    end function sweet_data_norm
+  
+
+    subroutine sweet_data_saxpy(this, a, x, flags)
+        class(sweet_data_encap_t), intent(inout)           :: this
+        class(pf_encap_t),         intent(in   )           :: x
+        real(pfdp),                intent(in   )           :: a
+        integer,                   intent(in   ), optional :: flags ! not used here
+    
+        class(sweet_data_encap_t), pointer                 :: x_sd_ptr
+
+        x_sd_ptr => as_sweet_data_encap(x)
+        
+        ! this = i_a * i_x + this
+        call c_sweet_data_saxpy(a,                         & 
+                                x_sd_ptr%c_sweet_data_ptr, &
+                                this%c_sweet_data_ptr)
+
+    end subroutine sweet_data_saxpy
+
+  
+    subroutine sweet_data_pack(this, z, flags)
+        class(sweet_data_encap_t), intent(in   ) :: this
+        real(pfdp),                intent(  out) :: z(:)
+        integer,                   intent(in   ), optional :: flags ! not used here
+
+        real(pfdp),                pointer       :: z_ptr(:)
+        type(c_ptr)                              :: z_c_ptr
+
+        ! get the data from the sweet object (PlaneData or SphereData)
+        call c_sweet_data_pack(this%c_sweet_data_ptr, &
+                               z_c_ptr)
+
+        ! convert the C pointer into a Fortran pointer
+        call c_f_pointer(z_c_ptr, &
+                         z_ptr,   &
+                         [this%data_size])
+
+        ! copy the data into z
+        z = z_ptr
+
+    end subroutine sweet_data_pack
+
+
+    subroutine sweet_data_unpack(this, z, flags)
+        class(sweet_data_encap_t), intent(inout)          :: this
+        real(pfdp),                intent(in   )          :: z(:)
+        integer,                   intent(in   ), optional :: flags ! not used here
+        real(pfdp),                               target  :: z2(size(z))
+
+        type(c_ptr)                                       :: z_c_ptr
+
+        ! the z2 array is needed because Fortran cannot pass assumed shape arrays to C++
+        ! this can probably be optimized
+        z2 = z
+
+        ! get a pointer to the first slot in the array
+        z_c_ptr = c_loc(z2(1))
+
+        ! copy the data array into the sweet object (PlaneData or SphereData)
+        call c_sweet_data_unpack(z_c_ptr, &
+                                 this%c_sweet_data_ptr)
+
+    end subroutine sweet_data_unpack
+
+
+    subroutine sweet_data_eprint(this, flags)
+        class(sweet_data_encap_t), intent(inout) :: this
+        integer,                   intent(in   ), optional :: flags ! not used here
+
+        call c_sweet_data_eprint(this%c_sweet_data_ptr)
+    end subroutine sweet_data_eprint
+
+end module encap_module
+

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/feval.f90
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/feval.f90
@@ -1,0 +1,228 @@
+module feval_module
+    use iso_c_binding 
+    use pf_mod_dtype
+    use encap_module
+    use pf_mod_utils
+    use pf_mod_imex_sweeper
+    use pf_mod_rkstepper
+    implicit none
+  
+    ! Define the derived sweeper type
+    type, extends(pf_imex_sweeper_t) :: sweet_sweeper_t
+        type(c_ptr)    :: ctx = c_null_ptr ! c pointer to PlaneDataCtx/SphereDataCtx
+        integer        :: nnodes           ! number of nodes
+        integer        :: sweep_niter      ! number of the current sweep
+        integer        :: sweep_niter_max  ! max number of sweeps
+        integer        :: level            ! level on which the sweeper is acting 
+        real(c_double) :: dt               ! full timestep size
+    contains 
+        procedure :: f_eval                => sweet_f_eval
+        procedure :: f_comp                => sweet_f_comp
+        procedure :: initialize            => sweet_sweeper_initialize
+        procedure :: destroy               => sweet_sweeper_destroy
+        procedure :: compute_dt            => sweet_sweeper_compute_dt
+    end type sweet_sweeper_t
+  
+    ! prototypes of the C functions
+
+    interface 
+        subroutine cinitial(i_ctx, i_t, i_dt, o_Y) bind(c, name="cinitial")
+            use iso_c_binding
+            type(c_ptr),    value :: i_ctx, o_Y
+            real(c_double), value :: i_t, i_dt 
+        end subroutine cinitial
+
+        subroutine cfinal(i_ctx, i_Y, i_nnodes, i_niter) bind(c, name="cfinal")
+            use iso_c_binding
+            type(c_ptr), value :: i_ctx, i_Y
+            integer,     value :: i_nnodes
+            integer,     value :: i_niter
+        end subroutine cfinal
+
+        subroutine ceval(i_Y, i_t, i_ctx, o_F) bind(c, name="ceval")
+            use iso_c_binding
+            type(c_ptr),    value :: i_Y, i_ctx, o_F
+            real(c_double), value :: i_t
+        end subroutine ceval
+
+        subroutine ccomp(io_Y, i_t, i_dt, i_Rhs, i_ctx, o_F) bind(c, name="ccomp")
+            use iso_c_binding
+            type(c_ptr),    value :: io_Y, i_Rhs, i_ctx, o_F
+            real(c_double), value :: i_t, i_dt
+        end subroutine ccomp
+
+        subroutine cfinalize(i_Y, i_t, i_dt, i_ctx) bind(c, name="cfinalize")
+            use iso_c_binding
+            type(c_ptr),    value :: i_Y, i_ctx
+            real(c_double), value :: i_t, i_dt
+        end subroutine cfinalize
+
+    end interface
+  
+contains
+
+    ! function to cast the pf_sweeper_t object into a sweet_sweeper_t object 
+    function as_sweet_sweeper(sweeper) result(r)
+        class(pf_sweeper_t),    intent(in), target  :: sweeper
+        class(sweet_sweeper_t),             pointer :: r
+
+        select type(sweeper)
+        type is (sweet_sweeper_t)
+            r => sweeper
+        class default
+            stop "TYPE ERROR"
+        end select
+
+    end function as_sweet_sweeper
+
+    ! initialization of the sweet data vector using z
+
+    subroutine finitial(sweeper, sd, z, t, dt)
+        class(pf_sweeper_t),       intent(inout) :: sweeper
+        class(pf_encap_t),         intent(inout) :: sd
+        class(pf_encap_t),         intent(inout) :: z
+        real(c_double),            intent(in)    :: t, dt
+
+        class(sweet_sweeper_t),    pointer       :: sweet_sweeper_ptr
+        class(sweet_data_encap_t), pointer       :: sd_ptr
+
+        sweet_sweeper_ptr => as_sweet_sweeper(sweeper)
+        sd_ptr            => as_sweet_data_encap(sd)
+
+        call cinitial(sweet_sweeper_ptr%ctx, & 
+                    t,                     &
+                    dt,                    &
+                    sd_ptr%c_sweet_data_ptr)
+
+        call z%copy(sd)
+
+    end subroutine finitial
+
+
+    subroutine ffinal(sweeper, sd, nnodes, niter)
+        use mpi 
+
+        class(pf_sweeper_t),       intent(in)    :: sweeper
+        class(pf_encap_t),         intent(inout) :: sd
+        integer,                   intent(in)    :: nnodes, niter
+
+        class(sweet_sweeper_t),    pointer       :: sweet_sweeper_ptr
+        class(sweet_data_encap_t), pointer       :: sd_ptr
+
+        sweet_sweeper_ptr => as_sweet_sweeper(sweeper)
+        sd_ptr            => as_sweet_data_encap(sd)
+
+        call cfinal(sweet_sweeper_ptr%ctx,   & 
+                    sd_ptr%c_sweet_data_ptr, &
+                    nnodes,                  &
+                    niter)
+
+    end subroutine ffinal  
+
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    !!             SWEEPER             !!
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    ! evaluate the right-hand side 
+
+    subroutine sweet_f_eval(this, y, t, level_index, f, piece)
+        class(sweet_sweeper_t),    intent(inout) :: this
+        class(pf_encap_t),         intent(in)    :: y
+        real(pfdp),                intent(in)    :: t
+        integer,                   intent(in)    :: level_index
+        class(pf_encap_t),         intent(inout) :: f
+        integer,                   intent(in)    :: piece
+
+        class(sweet_data_encap_t), pointer       :: y_sd_ptr
+        class(sweet_data_encap_t), pointer       :: f_sd_ptr
+        
+        y_sd_ptr  => as_sweet_data_encap(y)
+        f_sd_ptr  => as_sweet_data_encap(f)
+
+        if (piece == 1) then
+            call ceval(y_sd_ptr%c_sweet_data_ptr, &
+                    t,                         & 
+                    this%ctx,                  &  
+                    f_sd_ptr%c_sweet_data_ptr)
+        else
+            stop 'Bad value for piece in sweet_f_eval'
+        end if 
+
+    end subroutine sweet_f_eval
+
+  
+    ! solve for y in the implicit system + update f
+
+    subroutine sweet_f_comp(this, y, t, dtq, rhs, level_index, f, piece)
+        class(sweet_sweeper_t),   intent(inout) :: this
+        class(pf_encap_t),        intent(inout) :: y, f
+        real(pfdp),               intent(in)    :: t, dtq
+        class(pf_encap_t),        intent(in)    :: rhs
+        integer,                  intent(in)    :: level_index
+        integer,                  intent(in)    :: piece
+
+        class(sweet_data_encap_t), pointer      :: y_sd_ptr
+        class(sweet_data_encap_t), pointer      :: f_sd_ptr
+        class(sweet_data_encap_t), pointer      :: rhs_sd_ptr
+
+        y_sd_ptr   => as_sweet_data_encap(y)
+        f_sd_ptr   => as_sweet_data_encap(f)    
+        rhs_sd_ptr => as_sweet_data_encap(rhs) 
+
+        if (piece == 2) then
+            call ccomp(y_sd_ptr%c_sweet_data_ptr,   & 
+                    t,                           & 
+                    dtq,                         & 
+                    rhs_sd_ptr%c_sweet_data_ptr, &
+                    this%ctx,                    & 
+                    f_sd_ptr%c_sweet_data_ptr)
+        else
+            stop 'Bad value for piece in sweet_f_comp'
+        end if
+            
+    end subroutine sweet_f_comp
+
+    subroutine sweet_sweeper_initialize(this, pf, level_index)
+        class(sweet_sweeper_t), intent(inout)        :: this
+        type(pf_pfasst_t),      intent(inout),target :: pf
+        integer,                intent(in)           :: level_index
+        
+        ! call superclass initialize
+        call this%imex_initialize(pf, level_index)
+        
+        this%implicit=.TRUE.
+        this%explicit=.TRUE.
+    end subroutine sweet_sweeper_initialize
+  
+    ! destructor
+
+    subroutine sweet_sweeper_destroy(this, pf, level_index)
+        class(sweet_sweeper_t), intent(inout) :: this
+        type(pf_pfasst_t),   intent(inout),target :: pf
+        integer,             intent(in)    :: level_index
+
+        ! this is copy-pasted from LibPFASST, unsure about this
+        type(pf_level_t), pointer  :: lev       !  Current level
+        lev => pf%levels(level_index)           !  Assign level pointer
+
+        ! need the following line since the "final" keyword is not supported by some (older) compilers
+        ! it forces Fortran to destroy the parent class data structures
+        call this%imex_destroy(pf, level_index)
+    end subroutine sweet_sweeper_destroy
+
+    subroutine sweet_sweeper_compute_dt(this, pf, level_index, t0, dt, flags)
+        class(sweet_sweeper_t),         intent(inout) :: this
+        type(pf_pfasst_t), target,      intent(inout) :: pf
+        integer,                        intent(in   ) :: level_index
+        real(pfdp),                     intent(in   ) :: t0
+        real(pfdp),                     intent(inout) :: dt
+        integer, optional,              intent(in   ) :: flags
+
+        type(pf_level_t),    pointer :: lev
+        lev => pf%levels(level_index)   !!  Assign level pointer
+        !  Do nothing now (copy-pasted from pf_imex_sweeper)
+        return
+    end subroutine sweet_sweeper_compute_dt
+
+end module feval_module
+

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/feval.f90
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/feval.f90
@@ -39,17 +39,23 @@ module feval_module
             integer,     value :: i_niter
         end subroutine cfinal
 
-        subroutine ceval(i_Y, i_t, i_ctx, o_F) bind(c, name="ceval")
+        subroutine ceval_f1(i_Y, i_t, i_ctx, o_F) bind(c, name="ceval_f1")
             use iso_c_binding
             type(c_ptr),    value :: i_Y, i_ctx, o_F
             real(c_double), value :: i_t
-        end subroutine ceval
+        end subroutine ceval_f1
 
-        subroutine ccomp(io_Y, i_t, i_dt, i_Rhs, i_ctx, o_F) bind(c, name="ccomp")
+        subroutine ceval_f2(i_Y, i_t, i_ctx, o_F) bind(c, name="ceval_f2")
+            use iso_c_binding
+            type(c_ptr),    value :: i_Y, i_ctx, o_F
+            real(c_double), value :: i_t
+        end subroutine ceval_f2
+
+        subroutine ccomp_f2(io_Y, i_t, i_dt, i_Rhs, i_ctx, o_F) bind(c, name="ccomp_f2")
             use iso_c_binding
             type(c_ptr),    value :: io_Y, i_Rhs, i_ctx, o_F
             real(c_double), value :: i_t, i_dt
-        end subroutine ccomp
+        end subroutine ccomp_f2
 
         subroutine cfinalize(i_Y, i_t, i_dt, i_ctx) bind(c, name="cfinalize")
             use iso_c_binding
@@ -140,12 +146,15 @@ contains
         f_sd_ptr  => as_sweet_data_encap(f)
 
         if (piece == 1) then
-            call ceval(y_sd_ptr%c_sweet_data_ptr, &
+            call ceval_f1(y_sd_ptr%c_sweet_data_ptr, &
                     t,                         & 
                     this%ctx,                  &  
                     f_sd_ptr%c_sweet_data_ptr)
         else
-            stop 'Bad value for piece in sweet_f_eval'
+            call ceval_f2(y_sd_ptr%c_sweet_data_ptr, &
+                    t,                         & 
+                    this%ctx,                  &  
+                    f_sd_ptr%c_sweet_data_ptr)
         end if 
 
     end subroutine sweet_f_eval
@@ -170,7 +179,7 @@ contains
         rhs_sd_ptr => as_sweet_data_encap(rhs) 
 
         if (piece == 2) then
-            call ccomp(y_sd_ptr%c_sweet_data_ptr,   & 
+            call ccomp_f2(y_sd_ptr%c_sweet_data_ptr,   & 
                     t,                           & 
                     dtq,                         & 
                     rhs_sd_ptr%c_sweet_data_ptr, &

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/feval.f90
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/feval.f90
@@ -20,7 +20,6 @@ module feval_module
         procedure :: f_comp                => sweet_f_comp
         procedure :: initialize            => sweet_sweeper_initialize
         procedure :: destroy               => sweet_sweeper_destroy
-        procedure :: compute_dt            => sweet_sweeper_compute_dt
     end type sweet_sweeper_t
   
     ! prototypes of the C functions
@@ -51,17 +50,11 @@ module feval_module
             real(c_double), value :: i_t
         end subroutine ceval_f2
 
-        subroutine ccomp_f2(io_Y, i_t, i_dt, i_Rhs, i_ctx, o_F) bind(c, name="ccomp_f2")
+        subroutine ccomp_f2(io_Y, i_t, i_dtq, i_Rhs, i_ctx, o_F) bind(c, name="ccomp_f2")
             use iso_c_binding
             type(c_ptr),    value :: io_Y, i_Rhs, i_ctx, o_F
-            real(c_double), value :: i_t, i_dt
+            real(c_double), value :: i_t, i_dtq
         end subroutine ccomp_f2
-
-        subroutine cfinalize(i_Y, i_t, i_dt, i_ctx) bind(c, name="cfinalize")
-            use iso_c_binding
-            type(c_ptr),    value :: i_Y, i_ctx
-            real(c_double), value :: i_t, i_dt
-        end subroutine cfinalize
 
     end interface
   
@@ -218,20 +211,6 @@ contains
         ! it forces Fortran to destroy the parent class data structures
         call this%imex_destroy(pf, level_index)
     end subroutine sweet_sweeper_destroy
-
-    subroutine sweet_sweeper_compute_dt(this, pf, level_index, t0, dt, flags)
-        class(sweet_sweeper_t),         intent(inout) :: this
-        type(pf_pfasst_t), target,      intent(inout) :: pf
-        integer,                        intent(in   ) :: level_index
-        real(pfdp),                     intent(in   ) :: t0
-        real(pfdp),                     intent(inout) :: dt
-        integer, optional,              intent(in   ) :: flags
-
-        type(pf_level_t),    pointer :: lev
-        lev => pf%levels(level_index)   !!  Assign level pointer
-        !  Do nothing now (copy-pasted from pf_imex_sweeper)
-        return
-    end subroutine sweet_sweeper_compute_dt
 
 end module feval_module
 

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/fhooks.f90
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/fhooks.f90
@@ -1,0 +1,218 @@
+module hooks_module
+    use pf_mod_dtype
+    use encap_module
+    use feval_module
+    implicit none
+
+    interface
+     
+        ! prototypes of the C functions
+
+        subroutine cecho_error(sd,step) bind(c, name="cecho_error")
+            use iso_c_binding
+            type(c_ptr),intent(in),value :: sd
+            integer,intent(in)           :: step
+        end subroutine cecho_error
+
+        subroutine cecho_residual(i_ctx, i_norm, i_current_proc) &
+            bind(c, name="cecho_residual")
+            use iso_c_binding
+            type(c_ptr),     value :: i_ctx
+            integer,         value :: i_current_proc
+            real(c_double),  value :: i_norm
+        end subroutine cecho_residual
+
+        subroutine cecho_output_jump(i_ctx, i_Y, i_current_proc, i_current_step, i_current_iter, i_nnodes, i_niter) & 
+            bind(c, name="cecho_output_jump")
+            use iso_c_binding
+            type(c_ptr),     value :: i_ctx, i_Y
+            integer,         value :: i_current_proc, i_current_step, i_current_iter, i_nnodes, i_niter
+        end subroutine cecho_output_jump
+
+        subroutine cecho_output_solution(i_ctx, i_Y, i_current_proc, i_current_step, i_current_iter, i_nnodes, i_niter) & 
+            bind(c, name="cecho_output_solution")
+            use iso_c_binding
+            type(c_ptr),     value :: i_ctx, i_Y
+            integer,         value :: i_current_proc, i_current_step, i_current_iter, i_nnodes, i_niter
+        end subroutine cecho_output_solution
+
+        subroutine cecho_output_invariants(i_ctx, i_Y, i_current_proc, i_current_step, i_current_iter, i_nnodes, i_niter) & 
+            bind(c, name="cecho_output_invariants")
+            use iso_c_binding
+            type(c_ptr),     value :: i_ctx, i_Y
+            integer,         value :: i_current_proc, i_current_step, i_current_iter, i_nnodes, i_niter
+        end subroutine cecho_output_invariants
+
+    end interface
+
+contains
+
+    ! error function
+
+    subroutine fecho_error(pf, level_index)
+        use iso_c_binding
+        type(pf_pfasst_t), intent(inout) :: pf
+        integer, intent(in)              :: level_index
+
+        class(pf_encap_t),  allocatable   :: Y_reference
+
+        ! not implemented yet
+
+    end subroutine fecho_error
+
+  
+    ! function to output the residual 
+
+    subroutine fecho_residual(pf, level_index)
+        use iso_c_binding 
+        use pf_mod_utils
+        type(pf_pfasst_t), intent(inout) :: pf
+        integer, intent(in)              :: level_index
+
+        real(pfdp)                       :: resid
+        integer                          :: step,rank,iter
+
+        class(sweet_sweeper_t),    pointer       :: sweet_sweeper_ptr
+        class(sweet_data_encap_t), pointer       :: x_ptr
+
+        step=pf%state%step+1
+        rank=pf%rank
+        iter=pf%state%iter
+        resid=pf%levels(level_index)%residual
+
+        print '("resid: step: ",i7.5," iter: ",i5.3," level: ",i2.2," resid: ",es14.7)', &
+                step, iter, level_index, resid
+
+        sweet_sweeper_ptr => as_sweet_sweeper(pf%levels(level_index)%ulevel%sweeper)
+        x_ptr             => as_sweet_data_encap(pf%levels(level_index)%Q(sweet_sweeper_ptr%nnodes))
+
+        if (level_index == pf%nlevels) then
+            call cecho_residual(sweet_sweeper_ptr%ctx, &
+                                resid,                 &
+                                pf%state%proc-1)
+        end if
+    end subroutine fecho_residual
+
+    ! function to output the jump in the initial condition
+
+    subroutine fecho_output_jump(pf, level_index)
+        use iso_c_binding
+        use pf_mod_utils
+        use pf_mod_restrict
+        use mpi
+        type(pf_pfasst_t), intent(inout) :: pf
+        integer, intent(in)              :: level_index
+        
+        class(pf_encap_t),         allocatable   :: del
+        class(sweet_sweeper_t),    pointer       :: sweet_sweeper_ptr
+        class(sweet_data_encap_t), pointer       :: x_ptr
+        integer                                  :: ierr, num_procs
+
+        integer                          ::   proc,step,rank,iter
+        
+        call MPI_COMM_SIZE (MPI_COMM_WORLD, num_procs, ierr)
+
+        sweet_sweeper_ptr => as_sweet_sweeper(pf%levels(level_index)%ulevel%sweeper)
+
+        proc=pf%state%proc
+        step=pf%state%step
+        rank=pf%rank
+        iter=pf%state%iter
+
+        call pf%levels(level_index)%ulevel%factory%create_single(del,         &
+                                                                 level_index, &
+                                                                 pf%levels(level_index)%lev_shape)
+        call del%copy(pf%levels(level_index)%q0)
+        call del%axpy(-1.0_pfdp, pf%levels(level_index)%Q(1))
+        
+        x_ptr  => as_sweet_data_encap(del)
+
+        call cecho_output_jump(sweet_sweeper_ptr%ctx,         &
+                               x_ptr%c_sweet_data_ptr,        &
+                               proc,                          &
+                               step,                          &
+                               iter,                          &
+                               pf%levels(level_index)%nnodes, &
+                               pf%niters)
+
+    end subroutine fecho_output_jump
+  
+
+    ! function to output the solution
+
+    subroutine fecho_output_solution(pf, level_index)
+        use iso_c_binding
+        use pf_mod_utils
+        use pf_mod_restrict
+        use mpi
+        type(pf_pfasst_t), intent(inout) :: pf
+        integer, intent(in)              :: level_index
+
+        integer                          ::   proc,step,rank,iter
+
+        class(sweet_sweeper_t),    pointer       :: sweet_sweeper_ptr
+        class(sweet_data_encap_t), pointer       :: x_ptr
+        integer                                  :: ierr, num_procs
+
+        proc=pf%state%proc
+        step=pf%state%step
+        rank=pf%rank
+        iter=pf%state%iter
+
+        call MPI_COMM_SIZE (MPI_COMM_WORLD, num_procs, ierr)
+
+        sweet_sweeper_ptr => as_sweet_sweeper(pf%levels(level_index)%ulevel%sweeper)
+        x_ptr             => as_sweet_data_encap(pf%levels(level_index)%Q(sweet_sweeper_ptr%nnodes))
+
+        call cecho_output_solution(sweet_sweeper_ptr%ctx,         &
+                                   x_ptr%c_sweet_data_ptr,        &
+                                   proc,                          &
+                                   step,                          &
+                                   iter,                          &
+                                   pf%levels(level_index)%nnodes, &
+                                   pf%niters)
+
+    end subroutine fecho_output_solution
+
+    ! function to output the solution
+
+    subroutine fecho_output_invariants(pf, level_index)
+        use iso_c_binding
+        use pf_mod_utils
+        use pf_mod_restrict
+        use mpi
+        type(pf_pfasst_t), intent(inout) :: pf
+        integer, intent(in)              :: level_index
+
+        integer                          :: proc,step,rank,iter
+
+        class(sweet_sweeper_t),    pointer       :: sweet_sweeper_ptr
+        class(sweet_data_encap_t), pointer       :: x_ptr
+        integer                                  :: ierr, num_procs
+
+        proc=pf%state%proc
+        step=pf%state%step
+        rank=pf%rank
+        iter=pf%state%iter
+
+        call MPI_COMM_SIZE (MPI_COMM_WORLD, num_procs, ierr)
+
+        sweet_sweeper_ptr => as_sweet_sweeper(pf%levels(level_index)%ulevel%sweeper)
+        x_ptr             => as_sweet_data_encap(pf%levels(level_index)%Q(sweet_sweeper_ptr%nnodes))
+
+        if (modulo(step, 100) == 0 .and. iter == pf%niters) then
+
+            call cecho_output_invariants(sweet_sweeper_ptr%ctx,         &
+                                         x_ptr%c_sweet_data_ptr,        &
+                                         proc,                          &
+                                         step,                          &
+                                         iter,                          &
+                                         pf%levels(level_index)%nnodes, &
+                                         pf%niters)
+
+        end if
+        
+        end subroutine fecho_output_invariants
+
+end module hooks_module
+

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/fmain.f90
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/fmain.f90
@@ -1,0 +1,201 @@
+module main_module
+    use iso_c_binding 
+    use encap_module
+    use feval_module
+    use hooks_module
+    use transfer_module
+    use pf_mod_parallel
+    use pf_mod_mpi
+    use pfasst
+    implicit none
+
+    public :: fmain
+
+contains
+    function translate_qtype(name, nl) result (qtype)
+        integer :: nl
+        character(c_char), intent(in) :: name(nl)
+        character*72 :: tmp
+        integer :: qtype, i
+        logical :: use_no_left_q
+        do i=1,nl
+            tmp(i:i) = name(i)
+        end do
+        ! LibPFASST supports more quadrature types but we do not support them here
+        if (tmp(1:nl)      .eq. 'SDC_GAUSS_LOBATTO') then
+            qtype = SDC_GAUSS_LOBATTO
+        else if (tmp(1:nl) .eq. 'SDC_GAUSS_LEGENDRE') then
+            qtype = SDC_GAUSS_LEGENDRE
+        else
+            qtype = -1
+        end if
+    end function translate_qtype
+
+    ! main Fortran routine calling LibPFASST
+
+    subroutine fmain(user_ctx_ptr,                                                           & ! user-defined context
+                    nlevs, niters, nsweeps_coarse, nnodes, qtype_name, qnl, use_rk_stepper, & ! LibPFASST parameters
+                    nfields, nvars_per_field,                                               & ! SWEET parameters
+                    t_max, dt                                                               & ! timestepping parameters
+                    ) bind (c, name='fmain')
+        use mpi
+
+        type(c_ptr),                 value       :: user_ctx_ptr
+        integer                                  :: nlevs, niters, nsweeps_coarse, nnodes(nlevs), nvars(nlevs), shape(nlevs),   &
+                                                    nfields, nvars_per_field(nlevs), nsteps, level, qnl, qtype, use_rk_stepper, &
+                                                    ierror, num_procs, my_id, mpi_stat
+        logical                                  :: use_no_left_q
+        character(c_char)                        :: qtype_name
+        real(c_double)                           :: t, t_max, dt
+        class(pf_factory_t),         allocatable :: factory
+        class(sweet_data_factory_t), pointer     :: sd_factory_ptr
+        class(sweet_sweeper_t),      pointer     :: sweet_sweeper_ptr
+        type(pf_comm_t)                          :: pf_comm
+        type(pf_pfasst_t)                        :: pf
+
+        real(c_double),             allocatable  :: z(:), y(:)
+        real(c_double)                           :: val
+
+        print *, 'in fmain'
+
+        ! create the mpi and pfasst objects
+        call pf_mpi_create(pf_comm, MPI_COMM_WORLD);
+        print *, 'created mpi object'
+        print *, 'nlevs = ', nlevs
+        call pf_pfasst_create(pf, pf_comm, nlevels=1)
+        print *, 'created pfasst object'
+
+        call mpi_comm_rank(MPI_COMM_WORLD, my_id, ierror)
+        call mpi_comm_size(MPI_COMM_WORLD, num_procs, ierror)
+
+        if (my_id == 0) then
+            print *, 'Number of Processors: ', num_procs
+        end if
+        
+        ! timestepping parameters
+        t      = 0
+        nsteps = int(t_max/dt)
+
+        ! LibPFASST parameters
+        pf%nlevels           = nlevs                         ! number of SDC levels
+        pf%niters            = niters                        ! number of SDC iterations
+        pf%save_timings      = 1                             ! output the timings in fort.601 file
+        pf%qtype             = translate_qtype(qtype_name, & ! select the type of nodes
+                                            qnl)
+
+        if (nlevs == 1) then
+            nvars = [nfields*nvars_per_field(1)]    ! number of degrees of freedom for the levels
+        else 
+            stop 'This number of levels is not supported'
+        end if
+
+        ! initialize level-specific data structures
+        level = 1
+        pf%levels(level)%index = level
+        
+        call pf_level_set_size(pf, level, nvars)
+
+        ! define the number of internal rk time steps
+        pf%nsteps_rk = 1
+
+        pf%levels(level)%nsweeps      = 1
+        pf%levels(level)%nsweeps_pred = 1
+                
+
+        ! allocate space for the levels
+        pf%levels(level)%lev_shape = nvars(level)
+        
+        ! define the properties (number of degrees of freedom and number of SDC nodes)
+        pf%levels(level)%nnodes  = nnodes(level)
+        pf%levels(level)%Finterp = .false.
+
+        ! allocate space for the objects at this level
+        allocate(sweet_level_t::pf%levels(level)%ulevel)
+        allocate(sweet_data_factory_t::pf%levels(level)%ulevel%factory)
+        allocate(sweet_sweeper_t::pf%levels(level)%ulevel%sweeper)
+
+        ! cast the object into sweet data objects
+        sd_factory_ptr    => as_sweet_data_factory(pf%levels(level)%ulevel%factory)
+        sweet_sweeper_ptr => as_sweet_sweeper(pf%levels(level)%ulevel%sweeper)    
+
+        ! pass the pointer to sweet data context to LibPFASST
+        sd_factory_ptr%ctx    = user_ctx_ptr
+        sweet_sweeper_ptr%ctx = user_ctx_ptr
+
+        ! initialize the sweeper data
+        sweet_sweeper_ptr%level           = level
+        sweet_sweeper_ptr%nnodes          = nnodes(level)
+        sweet_sweeper_ptr%sweep_niter     = 0
+        sweet_sweeper_ptr%sweep_niter_max = pf%niters
+        sweet_sweeper_ptr%dt              = dt
+
+        ! initialize the pfasst objects
+        call pf_pfasst_setup(pf)
+
+        !! initialize the state vector
+        call finitial(pf%levels(pf%nlevels)%ulevel%sweeper, & 
+                      pf%levels(pf%nlevels)%Q(1),           & 
+                      pf%levels(pf%nlevels)%q0,             &
+                      t_max,                                &
+                      dt)
+        
+
+        call pf_add_hook(pf,                &
+                         -1,                &
+                         PF_POST_ITERATION, &
+                         fecho_residual)
+        if (num_procs > 1) then
+            call pf_add_hook(pf,                 &
+                             -1,                 &
+                             PF_PRE_INTERP_Q0,   &
+                             fecho_output_jump)
+        end if
+        if (num_procs .eq. 1) then
+            call pf_add_hook(pf,                 &
+                             -1,                 &
+                             PF_POST_ITERATION,  &
+                             fecho_output_solution)
+        else
+            call pf_add_hook(pf,                 &
+                             -1,                 &
+                             PF_POST_SWEEP,      &
+                             fecho_output_solution)
+        end if
+
+        call pf_add_hook(pf,                  &
+                         pf%nlevels,          &
+                         PF_POST_BLOCK,       &
+                         fecho_output_invariants)
+        
+        call pf_print_options(pf,un_opt=6)
+        
+        ! advance in time with libpfasst
+        level = nlevs
+
+        call MPI_BARRIER(MPI_COMM_WORLD,mpi_stat)
+
+        call pf_pfasst_run(pf,                    & 
+                           pf%levels(level)%Q(1), &
+                           dt,                    &
+                           t,                     &
+                           nsteps)
+        t = t + dt*nsteps
+
+        call MPI_BARRIER(MPI_COMM_WORLD,mpi_stat)
+        
+        ! finalize the simulation (does nothing right now)
+        call ffinal(pf%levels(level)%ulevel%sweeper,   & 
+                    pf%levels(level)%Q(nnodes(level)), &
+                    nnodes(level),                     &
+                    pf%niters)
+
+
+        call MPI_BARRIER(MPI_COMM_WORLD,mpi_stat)
+
+        ! release memory
+        call pf_pfasst_destroy(pf)
+
+    end subroutine fmain
+
+end module main_module
+

--- a/src/programs/libpfasst_swe_sphere_imex_sdc/ftransfer.f90
+++ b/src/programs/libpfasst_swe_sphere_imex_sdc/ftransfer.f90
@@ -1,0 +1,107 @@
+module transfer_module
+  use pf_mod_dtype
+  use encap_module
+  use feval_module
+  implicit none
+
+  type, extends(pf_user_level_t) :: sweet_level_t
+   contains 
+     procedure :: restrict    => sweet_data_restrict 
+     procedure :: interpolate => sweet_data_interpolate
+  end type sweet_level_t
+
+  interface 
+
+     ! prototypes of the C functions
+     
+     subroutine c_sweet_data_restrict(io_y_coarse, i_y_fine, i_level_coarse, i_level_fine, i_ctx, i_t) & 
+          bind(c, name="c_sweet_data_restrict")
+       use iso_c_binding
+       type(c_ptr),      value :: io_y_coarse, i_y_fine, i_ctx
+       integer,          value :: i_level_coarse, i_level_fine
+       double precision, value :: i_t
+     end subroutine c_sweet_data_restrict
+
+     subroutine c_sweet_data_interpolate(io_y_fine, i_y_coarse, i_level_fine, i_level_coarse, i_ctx, i_t) &
+          bind(c, name="c_sweet_data_interpolate")
+       use iso_c_binding
+       type(c_ptr),      value :: io_y_fine, i_y_coarse, i_ctx
+       integer,          value :: i_level_fine, i_level_coarse
+       double precision, value :: i_t
+     end subroutine c_sweet_data_interpolate
+     
+  end interface
+  
+contains
+
+  ! interpolation function
+
+  subroutine sweet_data_interpolate(this, f_lev, c_lev, f_vec, c_vec, t, flags)
+    class(sweet_level_t),    intent(inout) :: this
+    class(pf_level_t),       intent(inout) :: f_lev, c_lev ! fine and coarse levels
+    class(pf_encap_t),       intent(inout) :: f_vec, c_vec ! fine and coarse vectors
+    real(pfdp),              intent(in)    :: t
+    integer, optional,       intent(in)    :: flags
+
+    class(sweet_sweeper_t),  pointer       :: sweet_sweeper_ptr
+
+    sweet_sweeper_ptr => as_sweet_sweeper(this%sweeper)
+
+    select type(f_vec)
+    type is (sweet_data_encap_t)
+       select type(c_vec)
+       type is (sweet_data_encap_t)
+
+          call c_sweet_data_interpolate(f_vec%c_sweet_data_ptr,   &
+                                        c_vec%c_sweet_data_ptr,   &
+                                        f_lev%index-1,        & ! conversion to c++ indexing
+                                        c_lev%index-1,        & ! conversion to c++ indexing
+                                        sweet_sweeper_ptr%ctx, &
+                                        t)
+
+       class default
+          stop "TYPE ERROR"
+       end select
+    class default
+       stop "TYPE ERROR"
+    end select
+
+  end subroutine sweet_data_interpolate
+
+  
+  ! restriction function
+
+  subroutine sweet_data_restrict(this, f_lev, c_lev, f_vec, c_vec, t, flags)
+    class(sweet_level_t),    intent(inout) :: this
+    class(pf_level_t),       intent(inout) :: f_lev, c_lev ! fine and coarse levels
+    class(pf_encap_t),       intent(inout) :: f_vec, c_vec ! fine and coarse vectors
+    real(pfdp),              intent(in)    :: t
+    integer, optional,       intent(in)    :: flags
+    
+    class(sweet_sweeper_t),  pointer       :: sweet_sweeper_ptr
+
+    sweet_sweeper_ptr => as_sweet_sweeper(this%sweeper)
+
+    select type(f_vec)
+    type is (sweet_data_encap_t)
+       select type(c_vec)
+       type is (sweet_data_encap_t)
+          
+          call c_sweet_data_restrict(c_vec%c_sweet_data_ptr,   &
+                                     f_vec%c_sweet_data_ptr,   &
+                                     c_lev%index-1,        & ! conversion to c++ indexing
+                                     f_lev%index-1,        & ! conversion to c++ indexing
+                                     sweet_sweeper_ptr%ctx, &
+                                     t)
+
+       class default
+          stop "TYPE ERROR"
+       end select
+    class default
+       stop "TYPE ERROR"
+    end select
+
+  end subroutine sweet_data_restrict
+
+end module transfer_module
+

--- a/src/programs/libpfasst_swe_sphere_mlsdc/ceval.cpp
+++ b/src/programs/libpfasst_swe_sphere_mlsdc/ceval.cpp
@@ -426,7 +426,7 @@ void ceval_f2 (
 void ccomp_f2 (
 		SphereDataVars *io_Y,
 		double i_t,
-		double i_dt,
+		double i_dtq,
 		SphereDataVars *i_Rhs,
 		SphereDataCtx *i_ctx,
 		SphereDataVars *o_F2
@@ -594,7 +594,7 @@ void ceval_f3 (
 void ccomp_f3 (
 		SphereDataVars *io_Y,
 		double i_t,
-		double i_dt,
+		double i_dtq,
 		int i_level,
 		SphereDataVars *i_Rhs,
 		SphereDataCtx *i_ctx,
@@ -659,7 +659,7 @@ void ccomp_f3 (
 void cfinalize(
 		SphereDataVars *io_Y,
 		double i_t,
-		double i_dt,
+		double i_dtq,
 		SphereDataCtx *i_ctx
 )
 {
@@ -673,7 +673,7 @@ void cfinalize(
 	SphereData_Spectral& vrt_Y = io_Y->get_vrt();
 	SphereData_Spectral& div_Y  = io_Y->get_div();
 
-	const double scalar = simVars->sim.viscosity*i_dt;
+	const double scalar = simVars->sim.viscosity*i_dtq;
 	const double r      = simVars->sim.sphere_radius;
 
 	phi_pert_Y  = phi_pert_Y.spectral_solve_helmholtz(1.0,  -scalar, r);

--- a/src/programs/libpfasst_swe_sphere_mlsdc/ceval.hpp
+++ b/src/programs/libpfasst_swe_sphere_mlsdc/ceval.hpp
@@ -24,7 +24,7 @@ extern "C"
   void cinitial(
 		SphereDataCtx *i_ctx,
 		double i_t,
-		double i_dt, 
+		double i_dtq, 
 		SphereDataVars *o_Y
 		);
 
@@ -56,7 +56,7 @@ extern "C"
   void ccomp_f2 (
 		 SphereDataVars *io_Y, 
 		 double i_t, 
-		 double i_dt, 
+		 double i_dtq, 
 		 SphereDataVars *i_Rhs, 
 		 SphereDataCtx *i_ctx,
 		 SphereDataVars *o_F2 
@@ -73,7 +73,7 @@ extern "C"
   // solves the second implicit system
   void ccomp_f3 (SphereDataVars *io_Y, 
 		 double i_t, 
-		 double i_dt,
+		 double i_dtq,
 		 int i_level,
 		 SphereDataVars *i_Rhs,
 		 SphereDataCtx *i_ctx, 
@@ -83,7 +83,7 @@ extern "C"
   // applies artificial diffusion
   void cfinalize (SphereDataVars *io_Y,
 		  double i_t,
-		  double i_dt,
+		  double i_dtq,
 		  SphereDataCtx *i_ctx);
   
 }

--- a/src/programs/libpfasst_swe_sphere_mlsdc/feval.f90
+++ b/src/programs/libpfasst_swe_sphere_mlsdc/feval.f90
@@ -65,10 +65,10 @@ module feval_module
        real(c_double), value :: i_t
      end subroutine ceval_f2
 
-     subroutine ccomp_f2(io_Y, i_t, i_dt, i_Rhs, i_ctx, o_F2) bind(c, name="ccomp_f2")
+     subroutine ccomp_f2(io_Y, i_t, i_dtq, i_Rhs, i_ctx, o_F2) bind(c, name="ccomp_f2")
        use iso_c_binding
        type(c_ptr),    value :: io_Y, i_Rhs, i_ctx, o_F2
-       real(c_double), value :: i_t, i_dt
+       real(c_double), value :: i_t, i_dtq
      end subroutine ccomp_f2
 
      subroutine ceval_f3(i_Y, i_t, i_level, i_ctx, o_F3) bind(c, name="ceval_f3")
@@ -78,10 +78,10 @@ module feval_module
        real(c_double), value :: i_t
      end subroutine ceval_f3
 
-     subroutine ccomp_f3(i_Y, i_t, i_dt, i_level, i_Rhs, i_ctx, o_F3) bind(c, name="ccomp_f3")
+     subroutine ccomp_f3(i_Y, i_t, i_dtq, i_level, i_Rhs, i_ctx, o_F3) bind(c, name="ccomp_f3")
        use iso_c_binding
        type(c_ptr),    value :: i_Y, i_Rhs, i_ctx, o_F3
-       real(c_double), value :: i_t, i_dt
+       real(c_double), value :: i_t, i_dtq
        integer,        value :: i_level
      end subroutine ccomp_f3
 

--- a/tests/10_compile/10_compile_test_libpfasst_expl_sdc/test.sh
+++ b/tests/10_compile/10_compile_test_libpfasst_expl_sdc/test.sh
@@ -3,7 +3,7 @@
 cd "$MULE_SOFTWARE_ROOT"
 
 echo_info_hline
-echo_info "PFASST"
+echo_info "PFASST-EXPL-SDC"
 echo_info_hline
 
 

--- a/tests/10_compile/10_compile_test_libpfasst_imex_sdc/test.sh
+++ b/tests/10_compile/10_compile_test_libpfasst_imex_sdc/test.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+cd "$MULE_SOFTWARE_ROOT"
+
+echo_info_hline
+echo_info "PFASST-IMEX-SDC"
+echo_info_hline
+
+
+if [ -e "$MULE_LOCAL_ROOT/../local_software/local/lib/libpfasst.a" ]; then 
+
+	SCONS="scons --program=libpfasst_swe_sphere_imex_sdc --quadmath=disable --libpfasst=enable --sweet-mpi=enable --libsph=enable --plane-spectral-space=disable --sphere-spectral-space=enable --threading=off --libfft=enable --sphere-spectral-dealiasing=enable"
+	echo "$SCONS"
+	$SCONS || exit
+
+fi

--- a/tests/10_compile/10_compile_test_libpfasst_mlsdc/test.sh
+++ b/tests/10_compile/10_compile_test_libpfasst_mlsdc/test.sh
@@ -3,7 +3,7 @@
 cd "$MULE_SOFTWARE_ROOT"
 
 echo_info_hline
-echo_info "PFASST"
+echo_info "PFASST-MLSDC"
 echo_info_hline
 
 

--- a/tests/70_program_libpfasst_swe_sphere_expl_sdc_timestepper_convergence/benchmark_create_job_scripts.py
+++ b/tests/70_program_libpfasst_swe_sphere_expl_sdc_timestepper_convergence/benchmark_create_job_scripts.py
@@ -64,7 +64,6 @@ jg.runtime.output_timestep_size = jg.runtime.max_simulation_time
 # LibPFASST runtime parameters
 # set them all explicitly to make sure we know what's happening
 jg.runtime.libpfasst_nlevels = 1
-jg.runtime.libpfasst_nodes_type = 'SDC_GAUSS_LOBATTO'
 jg.runtime.libpfasst_use_rexi = 0
 jg.runtime.libpfasst_implicit_coriolis_force = 0
 jg.runtime.libpfasst_use_rk_stepper = 0
@@ -75,6 +74,7 @@ jg.runtime.libpfasst_use_rk_stepper = 0
 
 jg.runtime.libpfasst_nnodes = 5
 jg.runtime.libpfasst_niters = 8
+jg.runtime.libpfasst_nodes_type = 'SDC_GAUSS_LOBATTO'
 
 ref_ts_size = 8
 
@@ -98,6 +98,7 @@ timestep_sizes = [timestep_size_min*(2.0**i) for i in range(0, 6)]
 # Create job scripts
 #
 
+jg.runtime.libpfasst_nodes_type = 'SDC_GAUSS_LOBATTO'
 for jg.runtime.libpfasst_nnodes in [3,5]:
     for jg.runtime.libpfasst_niters in range(1,6):
         for jg.runtime.timestep_size in timestep_sizes:
@@ -108,5 +109,20 @@ for jg.runtime.libpfasst_nnodes in [3,5]:
                 raise Exception("Invalid time step size (not remainder-less dividable)")
             
             jg.runtime.timestepping_order = min(jg.runtime.libpfasst_niters, 2 * jg.runtime.libpfasst_nnodes - 2)
+
+            jg.gen_jobscript_directory()
+
+
+jg.runtime.libpfasst_nodes_type = 'SDC_GAUSS_LEGENDRE'
+for jg.runtime.libpfasst_nnodes in [3,5]:
+    for jg.runtime.libpfasst_niters in range(1,6):
+        for jg.runtime.timestep_size in timestep_sizes:
+
+            if jg.runtime.max_simulation_time % jg.runtime.timestep_size != 0:
+                print("simtime: "+str(jg.runtime.max_simulation_time))
+                print("timestep_size: "+str(jg.runtime.timestep_size))
+                raise Exception("Invalid time step size (not remainder-less dividable)")
+            
+            jg.runtime.timestepping_order = min(jg.runtime.libpfasst_niters, 2 * (jg.runtime.libpfasst_nnodes - 2))
 
             jg.gen_jobscript_directory()

--- a/tests/70_program_libpfasst_swe_sphere_expl_sdc_timestepper_convergence/postprocessing_convergence_test.py
+++ b/tests/70_program_libpfasst_swe_sphere_expl_sdc_timestepper_convergence/postprocessing_convergence_test.py
@@ -16,6 +16,7 @@ from matplotlib.lines import Line2D
 groups = [
     'runtime.libpfasst_nnodes',
     'runtime.libpfasst_niters',
+    'runtime.libpfasst_nodes_type',
 ]
 
 

--- a/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/benchmark_create_job_scripts.py
+++ b/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/benchmark_create_job_scripts.py
@@ -1,0 +1,112 @@
+#! /usr/bin/env python3
+
+import os
+import sys
+import stat
+import math
+
+from mule_local.JobMule import *
+jg = JobGeneration()
+
+###################################################
+# Compilation Settings for reference & tests jobs #
+###################################################
+
+jg.compile.program = 'libpfasst_swe_sphere_imex_sdc'
+
+# enable libpfasst
+jg.compile.libpfasst = 'enable'
+
+# run simulation on sphere, not plane
+jg.compile.plane_spectral_space = 'disable'
+jg.compile.plane_spectral_dealiasing = 'disable'
+jg.compile.sphere_spectral_space = 'enable'
+jg.compile.sphere_spectral_dealiasing = 'enable'
+
+# enable MPI
+jg.compile.sweet_mpi = 'enable'
+
+# other compilation settings
+jg.compile.libsph = 'enable'
+jg.compile.threading = 'off'
+jg.compile.libfft = 'enable'
+jg.compile.quadmath = 'enable'
+
+###############################################
+# Runtime Settings for reference & tests jobs #
+###############################################
+
+jg.runtime.output_file_mode = 'bin'
+
+# Verbosity mode
+jg.runtime.verbosity = 2
+
+# Mode and Physical resolution
+jg.runtime.space_res_spectral = 64
+jg.runtime.space_res_physical = None
+
+# Benchmark
+jg.runtime.benchmark_name = "galewsky"
+
+# Compute error
+jg.runtime.compute_error = 0
+
+jg.runtime.f_sphere = 0
+
+jg.runtime.viscosity = 0.0
+
+jg.unique_id_filter = ['compile', 'parallelization']
+
+timestep_size_min = 16
+jg.runtime.max_simulation_time = timestep_size_min*256
+jg.runtime.output_timestep_size = jg.runtime.max_simulation_time
+
+# LibPFASST runtime parameters
+# set them all explicitly to make sure we know what's happening
+jg.runtime.libpfasst_nlevels = 1
+jg.runtime.libpfasst_nodes_type = 'SDC_GAUSS_LOBATTO'
+jg.runtime.libpfasst_use_rexi = 0
+jg.runtime.libpfasst_implicit_coriolis_force = 0
+jg.runtime.libpfasst_use_rk_stepper = 0
+
+#################
+# Reference Job #
+#################
+
+jg.runtime.libpfasst_nnodes = 5
+jg.runtime.libpfasst_niters = 8
+
+ref_ts_size = 8
+
+jg.runtime.timestep_size = ref_ts_size
+
+jg.reference_job = True
+jg.gen_jobscript_directory()
+jg.reference_job = False
+
+# Use this one as the reference solution!
+jg.reference_job_unique_id = jg.job_unique_id
+
+
+#############
+# Test Jobs #
+#############
+
+timestep_sizes = [timestep_size_min*(2.0**i) for i in range(0, 6)]
+
+#
+# Create job scripts
+#
+
+for jg.runtime.libpfasst_nnodes in [3,5]:
+    for jg.runtime.libpfasst_niters in range(1,5):
+        for jg.runtime.timestep_size in timestep_sizes:
+
+            if jg.runtime.max_simulation_time % jg.runtime.timestep_size != 0:
+                print("simtime: "+str(jg.runtime.max_simulation_time))
+                print("timestep_size: "+str(jg.runtime.timestep_size))
+                raise Exception("Invalid time step size (not remainder-less dividable)")
+            
+            jg.runtime.timestepping_order = min(jg.runtime.libpfasst_niters, 2 * jg.runtime.libpfasst_nnodes - 2)
+
+            jg.gen_jobscript_directory()

--- a/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/benchmark_create_job_scripts.py
+++ b/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/benchmark_create_job_scripts.py
@@ -64,7 +64,6 @@ jg.runtime.output_timestep_size = jg.runtime.max_simulation_time
 # LibPFASST runtime parameters
 # set them all explicitly to make sure we know what's happening
 jg.runtime.libpfasst_nlevels = 1
-jg.runtime.libpfasst_nodes_type = 'SDC_GAUSS_LOBATTO'
 jg.runtime.libpfasst_use_rexi = 0
 jg.runtime.libpfasst_implicit_coriolis_force = 0
 jg.runtime.libpfasst_use_rk_stepper = 0
@@ -75,6 +74,7 @@ jg.runtime.libpfasst_use_rk_stepper = 0
 
 jg.runtime.libpfasst_nnodes = 5
 jg.runtime.libpfasst_niters = 8
+jg.runtime.libpfasst_nodes_type = 'SDC_GAUSS_LOBATTO'
 
 ref_ts_size = 8
 
@@ -98,6 +98,7 @@ timestep_sizes = [timestep_size_min*(2.0**i) for i in range(0, 6)]
 # Create job scripts
 #
 
+jg.runtime.libpfasst_nodes_type = 'SDC_GAUSS_LOBATTO'
 for jg.runtime.libpfasst_nnodes in [3,5]:
     for jg.runtime.libpfasst_niters in range(1,5):
         for jg.runtime.timestep_size in timestep_sizes:
@@ -108,5 +109,19 @@ for jg.runtime.libpfasst_nnodes in [3,5]:
                 raise Exception("Invalid time step size (not remainder-less dividable)")
             
             jg.runtime.timestepping_order = min(jg.runtime.libpfasst_niters, 2 * jg.runtime.libpfasst_nnodes - 2)
+
+            jg.gen_jobscript_directory()
+
+jg.runtime.libpfasst_nodes_type = 'SDC_GAUSS_LEGENDRE'
+for jg.runtime.libpfasst_nnodes in [3,5]:
+    for jg.runtime.libpfasst_niters in range(2,5):
+        for jg.runtime.timestep_size in timestep_sizes:
+
+            if jg.runtime.max_simulation_time % jg.runtime.timestep_size != 0:
+                print("simtime: "+str(jg.runtime.max_simulation_time))
+                print("timestep_size: "+str(jg.runtime.timestep_size))
+                raise Exception("Invalid time step size (not remainder-less dividable)")
+            
+            jg.runtime.timestepping_order = min(jg.runtime.libpfasst_niters, 2 * (jg.runtime.libpfasst_nnodes - 2))
 
             jg.gen_jobscript_directory()

--- a/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/postprocessing_convergence_test.py
+++ b/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/postprocessing_convergence_test.py
@@ -1,0 +1,187 @@
+#! /usr/bin/env python3
+
+import sys
+import math
+
+from mule_local.JobMule import *
+from mule.plotting.Plotting import *
+from mule.postprocessing.JobsData import *
+from mule.postprocessing.JobsDataConsolidate import *
+
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+
+
+
+groups = [
+    'runtime.libpfasst_nnodes',
+    'runtime.libpfasst_niters',
+]
+
+
+tagnames_y = [
+    'sphere_data_diff_prog_phi_pert.res_norm_linf',
+    'sphere_data_diff_prog_div.res_norm_linf',
+    'sphere_data_diff_prog_vrt.res_norm_linf',
+]
+
+
+j = JobsData(verbosity=0)
+
+c = JobsDataConsolidate(j)
+print("")
+print("Groups:")
+job_groups = c.create_groups(groups)
+for key, g in job_groups.items():
+    print(" + "+key)
+
+
+for tagname_y in tagnames_y:
+    print("*"*80)
+    print("Processing tagname "+tagname_y)
+    print("*"*80)
+
+    tagname_x = 'runtime.timestep_size'
+
+    if True:
+        """
+        Use plotting format to create (x/y) data
+        """
+        d = JobsData_GroupsPlottingScattered(
+                job_groups,
+                tagname_x,
+                tagname_y,
+                meta_attribute_name = 'runtime.timestepping_order',
+            )
+
+        for group_name, group_data in d.get_data_float().items():
+            print("*"*80)
+            print("Group: "+group_name)
+            prev_value = -1.0
+            conv = '-'
+            convergence_order = None
+            for (x, y, convergence_order_) in zip(group_data['x_values'], group_data['y_values'], group_data['meta_values']):
+
+                if prev_value > 0:
+                    conv = y/prev_value
+                elif prev_value == 0:
+                    conv = '[error=0]'
+
+                print("\t"+str(x)+"\t=>\t"+str(y)+"\tconvergence: "+str(conv))
+                prev_value = y
+
+                if convergence_order == None:
+                    convergence_order = convergence_order_
+                else:
+                    if convergence_order != convergence_order_:
+                        raise Exception("Convergence order mismatch!!!")
+
+
+            print("")
+            print("Testing convergence")
+
+            #
+            # Setup default values
+            #
+
+            # 'convergence', 'error'
+            test_type = 'convergence'
+
+            # Convergence tolerance
+            error_tolerance_convergence = 0.15
+
+            # Range to check for convergence
+            conv_test_range_start = 0
+            conv_test_range_end = 4
+
+            if 'vrt' in tagname_y or 'div' in tagname_y:
+
+                if 'exp' in group_name:
+                    test_type = 'error'
+                    error_tolerance_error = 1e-12
+
+
+            elif 'phi' in tagname_y:
+                if 'exp' in group_name:
+                    test_type = 'error'
+                    error_tolerance_error = 1e-4
+
+            else:
+                raise Exception("Tagname "+tagname_y+" unknown")
+
+
+            print(" + test_type: "+test_type)
+
+            if test_type == 'convergence':
+                print(" + error_tolerance_convergence: "+str(error_tolerance_convergence))
+            elif test_type == 'error':
+                print(" + error_tolerance_error: "+str(error_tolerance_error))
+
+            print(" + range start/end: "+str(conv_test_range_start)+", "+str(conv_test_range_end))
+
+            if len(group_data['meta_values']) < conv_test_range_end:
+                raise Exception("Not enough samples to run convergence test")
+
+            for i in range(len(group_data['meta_values'])):
+                if group_data['meta_values'][i] != group_data['meta_values'][0]:
+                    print("FATAL: Different convergence orders in same test")
+                    for i in range(len(group_data['meta_values'])):
+                        print("order: "+str(group_data['meta_values']))
+
+                    raise Exception("FATAL: Different convergence orders in same test")
+
+            l = len(group_data['x_values'])
+            if l < conv_test_range_end:
+                print("There are only "+str(l)+" values, but we need at least "+str(conv_test_range_end)+" values")
+                raise Exception("Not enough values to study convergence")
+
+            prev_value = -1.0
+            conv = '-'
+            for i in range(conv_test_range_start, conv_test_range_end):
+                x = group_data['x_values'][i]
+                y = group_data['y_values'][i]
+                meta = group_data['meta_values'][i]
+
+                if prev_value > 0:
+                    conv = y/prev_value
+                elif prev_value == 0:
+                    conv = '[error=0]'
+
+                error_convergence = '-'
+                if isinstance(conv, float):
+                    # Convergence order is stored in meta value
+                    target_conv = pow(2.0, meta)
+                    error_convergence = abs(conv - target_conv)/target_conv
+
+                print("\t"+str(x)+"\t=>\t"+str(y)+"\tconvergence: "+str(conv)+"\terror: "+str(error_convergence))
+
+                if test_type == 'convergence':
+                    # Test for convergence if exists
+                    if error_convergence != '-':
+                        if error_convergence > error_tolerance_convergence:
+                            print("Error: "+str(error_convergence))
+                            if len(sys.argv) <= 1:
+                                raise Exception("Convergence exceeds tolerance of "+str(error_tolerance_convergence))
+
+                elif test_type == 'error':
+                    # Alternate tests instead of convergence check
+                    # Convergence doesn't really make sense for REXI in the way how it's applied
+                    # This should be only used for l_exp and lg_exp
+                    # Just ensure that the errors are below a certain level
+                    if y > error_tolerance_error:
+                        print("Error: "+str(y))
+                        if len(sys.argv) <= 1:
+                             raise Exception("Error exceeds tolerance of "+str(error_tolerance_error))
+
+                else:
+                    raise Exception("Unknown test type "+test_type)
+
+                prev_value = y
+
+            if len(sys.argv) <= 1:
+                print("[OK]")
+
+        if len(sys.argv) <= 1:
+            print("*"*80)
+            print("Convergence tests successful")
+            print("*"*80)

--- a/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/postprocessing_convergence_test.py
+++ b/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/postprocessing_convergence_test.py
@@ -16,6 +16,7 @@ from matplotlib.lines import Line2D
 groups = [
     'runtime.libpfasst_nnodes',
     'runtime.libpfasst_niters',
+    'runtime.libpfasst_nodes_type',
 ]
 
 

--- a/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/postprocessing_pickle.py
+++ b/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/postprocessing_pickle.py
@@ -1,0 +1,10 @@
+#! /usr/bin/env python3
+
+import sys
+import math
+import glob
+
+from mule_local.postprocessing.pickle_SphereDataSpectralDiff import *
+from mule.exec_program import *
+
+pickle_SphereDataSpectralDiff()

--- a/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/test.sh
+++ b/tests/70_program_libpfasst_swe_sphere_imex_sdc_timestepper_convergence/test.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+cd "$(dirname $0)"
+
+mule.benchmark.cleanup_all || exit 1
+
+./benchmark_create_job_scripts.py $TIMESTEPPING_GROUP || exit 1
+
+mule.benchmark.jobs_run_directly || exit 1
+
+./postprocessing_pickle.py || exit 1
+
+./postprocessing_convergence_test.py || exit 1
+
+mule.benchmark.cleanup_all || exit 1


### PR DESCRIPTION
Compilation:

```bash
$ scons --program=libpfasst_swe_sphere_imex_sdc --quadmath=enable --libpfasst=enable --sweet-mpi=enable --libsph=enable --plane-spectral-space=disable --sphere-spectral-space=enable --threading=off --libfft=enable --mode=debug
```
Execution

```bash
$ ./build/libpfasst_*_release -M 128 -t 1800 --benchmark-name=galewsky --dt=180 --libpfasst-nlevels 1 --libpfasst-niters 5 --libpfasst-nnodes 3 --libpfasst-nodes-type=SDC_GAUSS_LOBATTO --output-file-mode=bin -o -1 -v 6 
```

See upcoming tutorial and documentation for further explanation of these function calls.

Further changes:

* renamed `dt` to `dtq` whenever PFASST actually passes the quadrature weight times dt instead of just dt to a function
* removed uncalled functions
* added Gauss-Legendre convergence tests
* more specific output in compilation tests