### PR TITLE
Fix: Remove PF_PRE_INTERP_Q0 hook

### DIFF
--- a/src/programs/libpfasst_swe_sphere_mlsdc/chooks.cpp
+++ b/src/programs/libpfasst_swe_sphere_mlsdc/chooks.cpp
@@ -104,46 +104,6 @@ extern "C"
         i_ctx->save_physical_invariants(i_current_step);
     }
 
-    void cecho_output_jump(SphereDataCtx *i_ctx,
-                           SphereDataVars *i_Y,
-                           int i_current_proc,
-                           int i_current_step,
-                           int i_current_iter,
-                           int i_nnodes,
-                           int i_niters
-                           )
-    {
-        const SphereData_Spectral& phi_pert_Y  = i_Y->get_phi_pert();
-        const SphereData_Spectral& vrt_Y = i_Y->get_vrt();
-        const SphereData_Spectral& div_Y  = i_Y->get_div();
-
-        // get the pointer to the Simulation Variables object
-        SimulationVariables* simVars = i_ctx->get_simulation_variables();
-        simVars->timecontrol.current_timestep_nr = i_current_step + 1;
-        auto current_dt = simVars->timecontrol.current_timestep_size;
-        simVars->timecontrol.current_simulation_time = (i_current_step + 1) * current_dt;
-
-        // write the data to file
-        std::string filename = "prog_jump_phi_pert_current_proc_"+std::to_string(i_current_proc)
-                                    +"_current_iter_"+std::to_string(i_current_iter)
-                                    +"_nnodes_"      +std::to_string(i_nnodes)
-                                    +"_niters_"      +std::to_string(i_niters);
-        write_file(*i_ctx, phi_pert_Y, filename.c_str());
-
-        filename = "prog_jump_vrt_current_proc_"+std::to_string(i_current_proc)
-                        +"_current_iter_"+std::to_string(i_current_iter)
-                        +"_nnodes_"      +std::to_string(i_nnodes)
-                        +"_niters_"      +std::to_string(i_niters);
-        write_file(*i_ctx, vrt_Y, filename.c_str());
-
-        filename = "prog_jump_div_current_proc_"+std::to_string(i_current_proc)
-                        +"_current_iter_"+std::to_string(i_current_iter)
-                        +"_nnodes_"      +std::to_string(i_nnodes)
-                        +"_niters_"      +std::to_string(i_niters);
-        write_file(*i_ctx, div_Y, filename.c_str());
-    }
-
-
 
     void cecho_output_solution(SphereDataCtx *i_ctx,
                                SphereDataVars *i_Y,

--- a/src/programs/libpfasst_swe_sphere_mlsdc/fhooks.f90
+++ b/src/programs/libpfasst_swe_sphere_mlsdc/fhooks.f90
@@ -94,52 +94,7 @@ contains
 
    end if
 
-  end subroutine fecho_residual
-
-  ! function to output the jump in the initial condition
-
-  subroutine fecho_output_jump(pf, level_index)
-    use iso_c_binding
-    use pf_mod_utils
-    use pf_mod_restrict
-    use mpi
-    type(pf_pfasst_t), intent(inout) :: pf
-    integer, intent(in)              :: level_index
-    
-    class(pf_encap_t),         allocatable   :: del
-    class(sweet_sweeper_t),    pointer       :: sweet_sweeper_ptr
-    class(sweet_data_encap_t), pointer       :: x_ptr
-    integer                                  :: ierr, num_procs
-
-    integer                          ::   proc,step,rank,iter
-    
-    call MPI_COMM_SIZE (MPI_COMM_WORLD, num_procs, ierr)
-
-    sweet_sweeper_ptr => as_sweet_sweeper(pf%levels(level_index)%ulevel%sweeper)
-
-    proc=pf%state%proc
-    step=pf%state%step
-    rank=pf%rank
-    iter=pf%state%iter
-
-    call pf%levels(level_index)%ulevel%factory%create_single(del,  &
-                                            level_index,           &
-                                            pf%levels(level_index)%lev_shape)
-    call del%copy(pf%levels(level_index)%q0)
-    call del%axpy(-1.0_pfdp, pf%levels(level_index)%Q(1))
-    
-    x_ptr  => as_sweet_data_encap(del)
-
-    call cecho_output_jump(sweet_sweeper_ptr%ctx,  &
-                           x_ptr%c_sweet_data_ptr, &
-                           proc,                   &
-                           step,                   &
-                           iter,                   &
-                           pf%levels(level_index)%nnodes,           &
-                           pf%niters)
-
-  end subroutine fecho_output_jump
-  
+  end subroutine fecho_residual  
 
   ! function to output the solution
 

--- a/src/programs/libpfasst_swe_sphere_mlsdc/fmain.f90
+++ b/src/programs/libpfasst_swe_sphere_mlsdc/fmain.f90
@@ -234,12 +234,6 @@ contains
                       -1,        &
                       PF_POST_ITERATION, &
                       fecho_residual)
-     if (num_procs > 1) then
-        call pf_add_hook(pf,                 &
-                         -1,         &
-                         PF_PRE_INTERP_Q0,   &
-                         fecho_output_jump)
-     end if
      if (num_procs .eq. 1) then
         call pf_add_hook(pf,                 &
                          -1,                 &


### PR DESCRIPTION
It is unclear and not well documented what this hook was used for and just created extra output files that were unexpected. I removed it for now.